### PR TITLE
Change Calendar Default Scroll Logic

### DIFF
--- a/stories/elements/Calendar/WeeklyCalendar/WithoutWeekControls.stories.tsx
+++ b/stories/elements/Calendar/WeeklyCalendar/WithoutWeekControls.stories.tsx
@@ -46,6 +46,8 @@ const defaultArgs: WeeklyCalendarProps = {
     header: null,
     weekOffset: 0,
     onWeekChange: () => {},
+    defaultScrollHour: 8.5,
+    shouldScrollToFirstEvent: true,
 };
 
 export const Component = Template.bind({});

--- a/stories/elements/Calendar/WeeklyCalendar/index.stories.tsx
+++ b/stories/elements/Calendar/WeeklyCalendar/index.stories.tsx
@@ -164,6 +164,8 @@ const defaultArgs: WeeklyCalendarProps = {
     weekOffset: 0,
     onWeekChange: () => {},
     loading: false,
+    defaultScrollHour: 8.5,
+    shouldScrollToFirstEvent: true,
 };
 
 export const Component = Template.bind({});

--- a/ui/elements/Calendar/WeeklyCalendar.tsx
+++ b/ui/elements/Calendar/WeeklyCalendar.tsx
@@ -45,6 +45,8 @@ export default function WeeklyCalendar<T>(props: WeeklyCalendarProps<T>) {
         weekOffset: initialWeekOffset = 0,
         onWeekChange = () => {},
         loading = false,
+        defaultScrollHour = 8.5,
+        shouldScrollToFirstEvent = true,
     } = props;
 
     const [weekOffset, setWeekOffset] = useState(initialWeekOffset);
@@ -169,19 +171,22 @@ export default function WeeklyCalendar<T>(props: WeeklyCalendarProps<T>) {
         }
         const target = getScrollableParent(containerRef.current);
 
-        let earliestEventTime = Infinity;
+        let scrollTop = CALENDAR_BLOCK_HEIGHT * defaultScrollHour;
 
-        Object.keys(calendarEvents || []).forEach((timestamp) => {
-            const cEvents = calendarEvents[parseInt(timestamp, 10)];
-            const hours = new Date(parseInt(timestamp, 10)).getHours();
-            if (cEvents && cEvents.length > 0) {
-                earliestEventTime = Math.min(earliestEventTime, hours);
+        if (shouldScrollToFirstEvent) {
+            let earliestEventTime = Infinity;
+
+            Object.keys(calendarEvents || []).forEach((timestamp) => {
+                const cEvents = calendarEvents[parseInt(timestamp, 10)];
+                const hours = new Date(parseInt(timestamp, 10)).getHours();
+                if (cEvents && cEvents.length > 0) {
+                    earliestEventTime = Math.min(earliestEventTime, hours);
+                }
+            });
+
+            if (earliestEventTime !== Infinity) {
+                scrollTop = CALENDAR_BLOCK_HEIGHT * (earliestEventTime - 1);
             }
-        });
-
-        let scrollTop = CALENDAR_BLOCK_HEIGHT * 8.5;
-        if (earliestEventTime !== Infinity) {
-            scrollTop = CALENDAR_BLOCK_HEIGHT * (earliestEventTime - 1);
         }
 
         target.scrollTo({ top: scrollTop, behavior: 'auto' });

--- a/ui/elements/Calendar/types.ts
+++ b/ui/elements/Calendar/types.ts
@@ -68,6 +68,18 @@ export interface WeeklyCalendarProps<T = {}> {
      * @default false
      */
     loading?: boolean;
+
+    /**
+     * The time in hours (24 hour format) to show at top initially.
+     * @default 8.5 (8:30 AM)
+     */
+    defaultScrollHour?: number;
+
+    /**
+     * A boolean indicating whether to scroll to the first event initially.
+     * @default true
+     */
+    shouldScrollToFirstEvent?: boolean;
 }
 
 export interface EventRendererProps<T = {}> {


### PR DESCRIPTION
- Add external props to ask the user for scroll settings.
- Add default initial scroll to show the first event in the calendar