### PR TITLE
Add min-width to StyledCheckboxButton for consistent sizing

### DIFF
--- a/ui/elements/Form/Checkbox/Checkbox.styles.ts
+++ b/ui/elements/Form/Checkbox/Checkbox.styles.ts
@@ -41,6 +41,7 @@ export const StyledCheckboxButton = styled.button<StyledCheckboxInputProps>`
         if ($size === 'small') {
             return css`
                 width: 12px;
+                min-width: 12px;
                 height: 12px;
                 border-width: 1.25px;
                 border-radius: 3px;
@@ -49,12 +50,14 @@ export const StyledCheckboxButton = styled.button<StyledCheckboxInputProps>`
         if ($size === 'large') {
             return css`
                 width: 20px;
+                min-width: 20px;
                 height: 20px;
                 border-width: 1.5px;
             `;
         }
         return css`
             width: 16px;
+            min-width: 16px;
             height: 16px;
             border-width: 1.4px;
             border-radius: 4px;


### PR DESCRIPTION
## Description
Checkbox is shrinking when label is too large

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues
https://github.com/Newton-School/grauity/issues/197

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
  - Incorrect: ❌ Dependency version update
  - Correct: ✅ Update version of framer-motion
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new TypeScript warnings
- [x] My changes does not hide eslint warnings un-necessarily
- [x] My pull request maintains linear history with the master branch to ensure that new changes are compatible with latest code.

## Screenshots

# Old
![image](https://github.com/user-attachments/assets/a21681fc-5d82-4874-8a50-b15352141534)

# Fixed in this PR
![image](https://github.com/user-attachments/assets/7ec7ec29-2c58-41fc-942b-b7500b1c1c6d)
