### PR TITLE
Fix Dropdown to ensure it does not open when disabled

### DIFF
--- a/ui/elements/Form/Dropdown/Dropdown.test.tsx
+++ b/ui/elements/Form/Dropdown/Dropdown.test.tsx
@@ -293,4 +293,42 @@ describe('Dropdown', () => {
 
         expect(onChange).toHaveBeenCalledWith(items[0]);
     });
+
+    it('When disabled, it should not show the dropdown when DEFAULT trigger is clicked', () => {
+        const onChange = jest.fn();
+        const items = getDummyOptions(3);
+
+        render(
+            <Dropdown
+                {...defaultProps}
+                placeholder="Select"
+                items={items}
+                onChange={onChange}
+                isDisabled
+            />
+        );
+
+        // Should not show the dropdown menu
+        fireEvent.click(screen.getByText('Select'));
+        expect(screen.queryByText('Item 0')).not.toBeInTheDocument();
+    });
+
+    it('When disabled, it should not show the dropdown menu when CUSTOM trigger is clicked', () => {
+        const onChange = jest.fn();
+        const items = getDummyOptions(3);
+
+        render(
+            <Dropdown
+                {...defaultProps}
+                items={items}
+                trigger={<button type="button">Custom Trigger</button>}
+                onChange={onChange}
+                isDisabled
+            />
+        );
+
+        // Should not show the dropdown menu
+        fireEvent.click(screen.getByText('Custom Trigger'));
+        expect(screen.queryByText('Item 0')).not.toBeInTheDocument();
+    });
 });

--- a/ui/elements/Form/Dropdown/DropdownTrigger.tsx
+++ b/ui/elements/Form/Dropdown/DropdownTrigger.tsx
@@ -83,6 +83,7 @@ const DropdownTrigger = forwardRef<
                 fullWidth
                 onClick={() => onTriggerClick()}
                 showAnimationOnClick={false}
+                disabled={isDisabled}
             >
                 <span>{getCurrentValue()}</span>
                 <Icon name="chevron-down" color="currentColor" />

--- a/ui/elements/Form/Dropdown/DropdownTrigger.tsx
+++ b/ui/elements/Form/Dropdown/DropdownTrigger.tsx
@@ -55,7 +55,11 @@ const DropdownTrigger = forwardRef<
         return (
             <StyledCustomTrigger
                 ref={ref as React.Ref<HTMLDivElement>}
-                onClick={() => onTriggerClick()}
+                onClick={() => {
+                    if (!isDisabled) {
+                        onTriggerClick();
+                    }
+                }}
             >
                 {trigger}
             </StyledCustomTrigger>


### PR DESCRIPTION
## Description

- Add test cases for disabled state for default and custom trigger
- Fix disabled state for default trigger (NSButton)
- Fix disabled state for custom trigger (not 100% coverage but for button and most input elements, should work)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Test updates

## Related Issues
- https://github.com/Newton-School/grauity/issues/199

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
  - Incorrect: ❌ Dependency version update
  - Correct: ✅ Update version of framer-motion
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new TypeScript warnings
- [x] My changes does not hide eslint warnings un-necessarily
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My pull request maintains linear history with the master branch to ensure that new changes are compatible with latest code.

## Screenshots

### Prod
![image](https://github.com/user-attachments/assets/003d5512-f481-4236-9065-6038d65eb7dd)

### After Fix
![image](https://github.com/user-attachments/assets/98829a5a-14eb-4522-9155-9bddfdd000ec)