### PR TITLE
Fix Alert component props & use `$` prefix for corresponsing styled components

### DIFF
--- a/ui/elements/Alert/Alert.styles.ts
+++ b/ui/elements/Alert/Alert.styles.ts
@@ -10,14 +10,19 @@ import {
 export const StyledAlertContainer = styled.div<AlertContainerProps>`
     display: flex;
     width: 100%;
-    ${({ maxWidth }) => maxWidth && `max-width: ${maxWidth};`}
+    ${({ $maxWidth }) => $maxWidth && `max-width: ${$maxWidth};`}
     min-height: var(--spacing-48px, 48px);
     align-items: flex-start;
     border-radius: var(--spacing-8px, 8px);
-    border: var(--spacing-1px, 1px) solid ${({ borderColor }) => borderColor};
-    background: ${({ backgroundColor }) => backgroundColor};
+    border: var(--spacing-1px, 1px) solid ${({ $borderColor }) => $borderColor};
+    background: ${({ $backgroundColor }) => $backgroundColor};
     padding: var(--spacing-12px, 12px);
     gap: var(--spacing-20px, 20px);
+    ${({ $position }) => $position && `position: ${$position};`}
+    ${({ $top }) => $top && `top: ${$top};`}
+    ${({ $bottom }) => $bottom && `bottom: ${$bottom};`}
+    ${({ $left }) => $left && `left: ${$left};`}
+    ${({ $right }) => $right && `right: ${$right};`}
 `;
 
 export const StyledAlertBody = styled.div<AlertBodyProps>`

--- a/ui/elements/Alert/Alert.tsx
+++ b/ui/elements/Alert/Alert.tsx
@@ -48,18 +48,18 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(({
 
     return (
         <StyledAlertContainer
-            position={position}
-            top={top}
-            bottom={bottom}
-            left={left}
-            right={right}
-            backgroundColor={backgroundColor}
-            borderColor={borderColor}
+            $position={position}
+            $top={top}
+            $bottom={bottom}
+            $left={left}
+            $right={right}
+            $backgroundColor={backgroundColor}
+            $borderColor={borderColor}
             ref={ref}
             role="alert"
             aria-labelledby={`alert-title-${id}`}
             aria-describedby={`alert-description-${id}`}
-            maxWidth={maxWidth}
+            $maxWidth={maxWidth}
         >
             {iconName && (
                 <Icon

--- a/ui/elements/Alert/types.ts
+++ b/ui/elements/Alert/types.ts
@@ -123,17 +123,17 @@ export interface AlertProps {
 }
 
 export interface AlertContainerProps {
-    position: string;
-    top: string;
-    bottom: string;
-    left: string;
-    right: string;
-    backgroundColor: string;
-    borderColor: string;
+    $position: string;
+    $top: string;
+    $bottom: string;
+    $left: string;
+    $right: string;
+    $backgroundColor: string;
+    $borderColor: string;
     ref: React.Ref<HTMLDivElement>;
     role: string;
     children: React.ReactNode;
-    maxWidth: string;
+    $maxWidth: string;
 }
 
 export interface AlertBodyProps {


### PR DESCRIPTION
These props were not working for NSAlert:
- position
- top
- left
- bottom
- right

Also refactored to use $ prefix for styled components here