### PR TITLE
Fix/dropdown scroll issue

### DIFF
--- a/ui/css/index.scss
+++ b/ui/css/index.scss
@@ -1,2 +1,2 @@
 @import "reset";
-@import "grauity-icons";
+ add

--- a/ui/css/index.scss
+++ b/ui/css/index.scss
@@ -1,2 +1,2 @@
 @import "reset";
-@import "grauity-icons";
+// @import "grauity-icons";

--- a/ui/css/index.scss
+++ b/ui/css/index.scss
@@ -1,2 +1,2 @@
 @import "reset";
-// @import "grauity-icons";
+@import "grauity-icons";

--- a/ui/elements/DropdownMenu/DropdownMenu.styles.ts
+++ b/ui/elements/DropdownMenu/DropdownMenu.styles.ts
@@ -62,7 +62,7 @@ export const StyledDropdownMenuHeaderSubtext = styled.div`
 
 export const StyledDropdownMenuBody = styled.div`
     display: flex;
-
+    padding: 4px 12px;
     flex-direction: column;
     align-items: flex-start;
     align-self: stretch;
@@ -96,7 +96,7 @@ export const StyledDropdownMenuSearchBox = styled.div`
 
 export const StyledDropdownMenuSubHeader = styled.div`
     display: flex;
-    padding: 0px 4px;
+    padding: 8px 4px;
     align-items: center;
     gap: 4px;
     align-self: stretch;
@@ -198,7 +198,7 @@ export const StyledDropdownMenuOptionDescription = styled.div<StyledDropdownMenu
 `;
 
 export const StyledDropdownMenuFooter = styled.div`
-    padding: 50px 16px 6px 16px;
+    padding: 14px 16px 6px 16px;
     display: flex;
     flex-direction: row-reverse;
     justify-content: space-between;

--- a/ui/elements/DropdownMenu/DropdownMenu.styles.ts
+++ b/ui/elements/DropdownMenu/DropdownMenu.styles.ts
@@ -23,6 +23,8 @@ export const StyledDropdownMenu = styled(motion.div)<StyledDropdownMenuProps>`
     border: 1px solid var(--border-subtle-primary-default, #e1e5ea);
     background: var(--bg-subtle-primary-default, #fff);
     overflow: hidden;
+    position: relative;
+    z-index: 1;
 
     * {
         box-sizing: border-box;
@@ -60,7 +62,7 @@ export const StyledDropdownMenuHeaderSubtext = styled.div`
 
 export const StyledDropdownMenuBody = styled.div`
     display: flex;
-    padding: 4px 12px;
+
     flex-direction: column;
     align-items: flex-start;
     align-self: stretch;
@@ -68,6 +70,15 @@ export const StyledDropdownMenuBody = styled.div`
     overflow: auto;
     position: relative;
     gap: 4px;
+`;
+
+export const StyledDropdownOptionsContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    overflow-y: auto;
+    max-height: 200px;
+    width: 100%;
 `;
 
 export const StyledDropdownMenuSearchBox = styled.div`
@@ -85,7 +96,7 @@ export const StyledDropdownMenuSearchBox = styled.div`
 
 export const StyledDropdownMenuSubHeader = styled.div`
     display: flex;
-    padding: 8px 4px;
+    padding: 0px 4px;
     align-items: center;
     gap: 4px;
     align-self: stretch;
@@ -187,7 +198,7 @@ export const StyledDropdownMenuOptionDescription = styled.div<StyledDropdownMenu
 `;
 
 export const StyledDropdownMenuFooter = styled.div`
-    padding: 14px 16px 6px 16px;
+    padding: 50px 16px 6px 16px;
     display: flex;
     flex-direction: row-reverse;
     justify-content: space-between;

--- a/ui/elements/DropdownMenu/DropdownMenu.tsx
+++ b/ui/elements/DropdownMenu/DropdownMenu.tsx
@@ -21,6 +21,7 @@ import {
     StyledDropdownMenu,
     StyledDropdownMenuBody,
     StyledDropdownMenuDivider,
+    StyledDropdownOptionsContainer,
 } from './DropdownMenu.styles';
 import {
     BaseItemOptionProps,
@@ -250,7 +251,7 @@ const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
                     subtext={subtext}
                     customHeader={customHeader}
                 />
-                <StyledDropdownMenuBody onScroll={handleMenuBodyScroll}>
+                <StyledDropdownMenuBody>
                     <DropdownSearchBox
                         searchRef={searchRef}
                         searchable={searchable}
@@ -266,97 +267,99 @@ const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
                             )
                         }
                     />
-                    {Array.isArray(searchedOptions) &&
-                        searchedOptions.map((item, index) => (
-                            <DropdownMenuOption
-                                optionRef={(el) => {
-                                    searchedItemRefs.current[index] = el;
-                                }}
-                                multiple={multiple}
-                                selected={selectedOptions
-                                    .map((option) => option.value)
-                                    .includes(item.value)}
-                                onClick={(clickedValue) =>
-                                    handleClickOption(
-                                        options.find(
-                                            (option) =>
-                                                option.value === clickedValue
+
+                    <StyledDropdownOptionsContainer onScroll={handleMenuBodyScroll}>
+                        {Array.isArray(searchedOptions) &&
+                            searchedOptions.map((item, index) => (
+                                <DropdownMenuOption
+                                    optionRef={(el) => {
+                                        searchedItemRefs.current[index] = el;
+                                    }}
+                                    multiple={multiple}
+                                    selected={selectedOptions
+                                        .map((option) => option.value)
+                                        .includes(item.value)}
+                                    onClick={(clickedValue) =>
+                                        handleClickOption(
+                                            options.find(
+                                                (option) => option.value === clickedValue
+                                            )
                                         )
-                                    )
-                                }
-                                onKeyDown={(event) =>
-                                    handleKeyDown(
-                                        event,
-                                        index,
-                                        searchedOptions,
-                                        searchedItemRefs
-                                    )
-                                }
-                                {...item}
-                            />
-                        ))}
-                    {!Array.isArray(searchedOptions) &&
-                        items.map((item, index) => {
-                            if (item.type === BaseItemType.SUB_HEADER) {
-                                return (
-                                    <DropdownMenuSubHeader
-                                        key={`${item.type}-${item.title}`}
-                                        itemRef={(el) => {
-                                            itemRefs.current[index] = el;
-                                        }}
-                                        onKeyDown={(event) =>
-                                            handleKeyDown(
-                                                event,
-                                                index,
-                                                items,
-                                                itemRefs
-                                            )
-                                        }
-                                        {...item}
-                                    />
-                                );
-                            }
-                            if (item.type === BaseItemType.DIVIDER) {
-                                return (
-                                    <StyledDropdownMenuDivider
-                                        key={`${item.type}`}
-                                    />
-                                );
-                            }
-                            if (item.type === BaseItemType.OPTION) {
-                                return (
-                                    <DropdownMenuOption
-                                        key={`${item.type}-${item.value}`}
-                                        optionRef={(el) => {
-                                            itemRefs.current[index] = el;
-                                        }}
-                                        multiple={multiple}
-                                        selected={selectedOptions
-                                            .map((option) => option.value)
-                                            .includes(item.value)}
-                                        onClick={(clickedValue) =>
-                                            handleClickOption(
-                                                options.find(
-                                                    (option) =>
-                                                        option.value ===
-                                                        clickedValue
+                                    }
+                                    onKeyDown={(event) =>
+                                        handleKeyDown(
+                                            event,
+                                            index,
+                                            searchedOptions,
+                                            searchedItemRefs
+                                        )
+                                    }
+                                    {...item}
+                                />
+                            ))}
+
+                        {!Array.isArray(searchedOptions) &&
+                            items.map((item, index) => {
+                                if (item.type === BaseItemType.SUB_HEADER) {
+                                    return (
+                                        <DropdownMenuSubHeader
+                                            key={`${item.type}-${item.title}`}
+                                            itemRef={(el) => {
+                                                itemRefs.current[index] = el;
+                                            }}
+                                            onKeyDown={(event) =>
+                                                handleKeyDown(
+                                                    event,
+                                                    index,
+                                                    items,
+                                                    itemRefs
                                                 )
-                                            )
-                                        }
-                                        onKeyDown={(event) =>
-                                            handleKeyDown(
-                                                event,
-                                                index,
-                                                items,
-                                                itemRefs
-                                            )
-                                        }
-                                        {...item}
-                                    />
-                                );
-                            }
-                            return null;
-                        })}
+                                            }
+                                            {...item}
+                                        />
+                                    );
+                                }
+                                if (item.type === BaseItemType.DIVIDER) {
+                                    return (
+                                        <StyledDropdownMenuDivider
+                                            key={`${item.type}`}
+                                        />
+                                    );
+                                }
+                                if (item.type === BaseItemType.OPTION) {
+                                    return (
+                                        <DropdownMenuOption
+                                            key={`${item.type}-${item.value}`}
+                                            optionRef={(el) => {
+                                                itemRefs.current[index] = el;
+                                            }}
+                                            multiple={multiple}
+                                            selected={selectedOptions
+                                                .map((option) => option.value)
+                                                .includes(item.value)}
+                                            onClick={(clickedValue) =>
+                                                handleClickOption(
+                                                    options.find(
+                                                        (option) =>
+                                                            option.value === clickedValue
+                                                    )
+                                                )
+                                            }
+                                            onKeyDown={(event) =>
+                                                handleKeyDown(
+                                                    event,
+                                                    index,
+                                                    items,
+                                                    itemRefs
+                                                )
+                                            }
+                                            {...item}
+                                        />
+                                    );
+                                }
+                                return null;
+                            })}
+                    </StyledDropdownOptionsContainer>
                 </StyledDropdownMenuBody>
                 <DropdownMenuFooter
                     multiple={multiple}


### PR DESCRIPTION
## Description

- Fixed an issue where dropdown options were appearing above the search bar on scroll.
- The scrollable container was overlapping with the sticky search box due to improper layout structure.
- Introduced a wrapper (`StyledDropdownOptionsContainer`) to isolate scroll behavior and applied correct `z-index` and `overflow` rules.
- Ensured consistent behavior across different screen sizes and devices by testing with multiple viewports.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #210  (Dropdown options overlap with header/search bar)

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new TypeScript warnings
- [x] My changes do not hide eslint warnings unnecessarily
- [x] My pull request maintains linear history with the master branch

## Additional Notes

- This fix is scoped only to the dropdown scroll issue and does not affect any unrelated UI components.
- Styling values like `padding`, `z-index`, and `max-height` were verified in Storybook.

## Reference Video


https://github.com/user-attachments/assets/bc72fb5b-279b-40e9-bf3b-5d32f41891f2


