### PR TITLE
convert non-DOM props in styled-components to transient props

### DIFF
--- a/stories/helper-components/TokenBlock/index.styles.ts
+++ b/stories/helper-components/TokenBlock/index.styles.ts
@@ -15,8 +15,8 @@ export const StyledTokenBlock = styled.div<any>`
     gap: 8px;
     border-radius: var(--corner-radius-8px, 8px);
     border: 1px solid var(--border, #e1e5ea);
-    background: ${({ background }) =>
-        background || 'var(--bg-tertiary, #edeff3)'};
+    background: ${({ $background }) =>
+        $background || 'var(--bg-tertiary, #edeff3)'};
     color: var(--text-primary, #16191d) !important;
     font-family: var(--font-family-code, 'Fira Code', 'monospace') !important;
     font-size: var(--font-size-14px, 14px) !important;
@@ -26,8 +26,8 @@ export const StyledTokenBlock = styled.div<any>`
     position: relative;
     overflow: hidden;
 
-    ${({ interactive }) =>
-        interactive &&
+    ${({ $interactive }) =>
+        $interactive &&
         css`
             cursor: pointer;
         `}
@@ -55,8 +55,8 @@ export const StyledTokenBlockCopiedContainer = styled.div<any>`
     transition: all 0.3s ease;
     z-index: -1;
 
-    ${({ copied }) =>
-        copied &&
+    ${({ $copied }) =>
+        $copied &&
         css`
             z-index: 1;
             opacity: 1;


### PR DESCRIPTION
Refactored all styled-components to use transient props
Converted all non-DOM props to transient props (prefixed with $) to avoid React DOM warnings and follow styled-components best practices.

Fixes: #221