### PR TITLE
docs(Checkbox): fix isChecked and value prop descriptions (#202)

### DIFF
--- a/ui/elements/Form/Checkbox/types.ts
+++ b/ui/elements/Form/Checkbox/types.ts
@@ -58,7 +58,11 @@ export interface CheckboxProps {
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
     /**
-     * Indicates if the checkbox is checked initially.
+     * Controls the current checked state of the checkbox.
+     *
+     * This is a controlled prop. You must manage this value in the parent component,
+     * and update it based on user interaction via the `onChange` callback.
+     *
      * @default false
      */
     isChecked?: boolean;


### PR DESCRIPTION
Fixed the isChecked prop description to clarify it controls the current checked state as a controlled prop.

Added description for the value prop explaining its role.

Improved documentation clarity for the Checkbox component props.

Fixes #202