### PR TITLE
Add test for Carousel component classnames

### DIFF
--- a/ui/elements/Carousel/Carousel.test.tsx
+++ b/ui/elements/Carousel/Carousel.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import Carousel from './Carousel';
+import { CLASSNAMES } from './constants';
 
 const DummyItem = ({ children }: { children: React.ReactNode }) => (
     <div style={{ width: '200px' }}>{children}</div>
@@ -50,6 +51,42 @@ describe('Carousel Component', () => {
         expect(item1).toBeInTheDocument();
         expect(item2).toBeInTheDocument();
         expect(item3).toBeInTheDocument();
+    });
+
+    // ClassName Application
+    it('should apply internal classnames correctly', () => {
+        const { container } = render(
+            <Carousel
+                title="Custom Title"
+                items={[
+                    <DummyItem key="1">Item 1</DummyItem>,
+                    <DummyItem key="2">Item 2</DummyItem>,
+                    <DummyItem key="3">Item 3</DummyItem>,
+                ]}
+            />
+        );
+
+        const headerRow = container.querySelector(
+            `.${CLASSNAMES.NS_CAROUSEL_HEADER_ROW}`
+        );
+        const title = container.querySelector(`.${CLASSNAMES.NS_CAROUSEL_TITLE}`);
+        const controls = container.querySelector(
+            `.${CLASSNAMES.NS_CAROUSEL_CONTROLS}`
+        );
+        const itemsContainer = container.querySelector(
+            `.${CLASSNAMES.NS_CAROUSEL_ITEMS_CONTAINER}`
+        );
+        const items = container.querySelectorAll(`.${CLASSNAMES.NS_CAROUSEL_ITEM}`);
+
+        expect(headerRow).toBeInTheDocument();
+        expect(title).toBeInTheDocument();
+        expect(controls).toBeInTheDocument();
+        expect(itemsContainer).toBeInTheDocument();
+        expect(items.length).toBe(3);
+        items.forEach((item) => {
+            expect(item).toBeInTheDocument();
+            expect(item).toHaveClass(CLASSNAMES.NS_CAROUSEL_ITEM);
+        });
     });
 
     // Less items


### PR DESCRIPTION
## Summary
- verify carousel classnames are exported
- add test to ensure internal classnames are applied correctly

## Testing
- `npm test` *(fails: jest not found)*