### PR TITLE
Add missing className props

### DIFF
--- a/ui/elements/Alert/Alert.test.tsx
+++ b/ui/elements/Alert/Alert.test.tsx
@@ -78,4 +78,9 @@ describe('Alert', () => {
         fireEvent.click(screen.getByText('Button 1'));
         expect(actionButtons[0].onClick).toHaveBeenCalledTimes(1);
     });
+
+    it('applies custom class name', () => {
+        render(<Alert {...defaultProps} className="custom-class" />);
+        expect(screen.getByRole('alert')).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/Alert/Alert.tsx
+++ b/ui/elements/Alert/Alert.tsx
@@ -38,6 +38,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(({
     actionButtons = [],
     inlineButtons = false,
     maxWidth = '440px',
+    className = '',
 }, ref) => {
     const id = useId();
     const iconName = getAlertIconName(icon, variant);
@@ -60,6 +61,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(({
             aria-labelledby={`alert-title-${id}`}
             aria-describedby={`alert-description-${id}`}
             $maxWidth={maxWidth}
+            className={className}
         >
             {iconName && (
                 <Icon

--- a/ui/elements/Alert/types.ts
+++ b/ui/elements/Alert/types.ts
@@ -120,6 +120,12 @@ export interface AlertProps {
      * Default: `'440px'`
      * */
     maxWidth?: string;
+
+    /**
+     * Additional class name for the alert container
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface AlertContainerProps {

--- a/ui/elements/AlertBanner/AlertBanner.test.tsx
+++ b/ui/elements/AlertBanner/AlertBanner.test.tsx
@@ -67,4 +67,9 @@ describe('AlertBanner', () => {
         fireEvent.click(screen.getByRole('button'));
         expect(onClose).toHaveBeenCalledTimes(1);
     });
+
+    it('applies custom class name', () => {
+        render(<AlertBanner className="custom-class">Banner</AlertBanner>);
+        expect(screen.getByRole('alert')).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/AlertBanner/AlertBanner.tsx
+++ b/ui/elements/AlertBanner/AlertBanner.tsx
@@ -37,6 +37,7 @@ const AlertBanner = forwardRef<HTMLDivElement, AlertBannerProps>(
             onClose,
             showCloseButton = false,
             actionButtons = [],
+            className = '',
         },
         ref
     ) => {
@@ -61,6 +62,7 @@ const AlertBanner = forwardRef<HTMLDivElement, AlertBannerProps>(
                 right={right}
                 position={position}
                 ref={ref}
+                className={className}
                 textColor={textColor}
                 backgroundColor={backgroundColor}
                 borderColor={borderColor}

--- a/ui/elements/AlertBanner/types.ts
+++ b/ui/elements/AlertBanner/types.ts
@@ -112,6 +112,12 @@ export interface AlertBannerProps {
      * Type: ButtonProps[]
      * */
     actionButtons?: ButtonProps[];
+
+    /**
+     * Additional class name for the alert banner container
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface AlertBannerContainerProps {

--- a/ui/elements/Calendar/MonthlyCalendar/MonthlyCalendar.test.tsx
+++ b/ui/elements/Calendar/MonthlyCalendar/MonthlyCalendar.test.tsx
@@ -73,4 +73,15 @@ describe('MonthlyCalendar', () => {
             screen.getAllByText('Test renderDayItem Call').length
         ).toBeGreaterThan(0);
     });
+
+    it('applies custom class name', async () => {
+        render(
+            <MonthlyCalendar {...defaultProps} className="custom-class" />
+        );
+        await waitFor(() => {
+            expect(
+                screen.getByLabelText(/Monthly Calendar for the month/i)
+            ).toHaveClass('custom-class');
+        });
+    });
 });

--- a/ui/elements/Calendar/MonthlyCalendar/MonthlyCalendar.tsx
+++ b/ui/elements/Calendar/MonthlyCalendar/MonthlyCalendar.tsx
@@ -26,6 +26,7 @@ function MonthlyCalendar<T>(props: MonthlyCalendarProps<T>) {
         events = [],
         renderDayItem,
         onPopOverClose = () => {},
+        className = '',
     } = props;
     const [currentDate, setCurrentDate] = useState(date);
     const monthOffset = getMonthOffsetByDate(currentDate);
@@ -89,6 +90,7 @@ function MonthlyCalendar<T>(props: MonthlyCalendarProps<T>) {
             aria-label={`Monthly Calendar for the month ${getMonthLabel(
                 new Date(currentYear, currentMonth)
             )}`}
+            className={className}
         >
             <StyledCalendarHeader>
                 {header}

--- a/ui/elements/Calendar/MonthlyCalendar/types.ts
+++ b/ui/elements/Calendar/MonthlyCalendar/types.ts
@@ -59,6 +59,12 @@ export interface MonthlyCalendarProps<T = {}> {
      * @default () => {}
      */
     onPopOverClose?: () => void;
+
+    /**
+     * Additional class name for the calendar container
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface DateCircleProps {

--- a/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.test.tsx
+++ b/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.test.tsx
@@ -67,12 +67,18 @@ describe('UnifiedCalendar', () => {
 
     it('applies custom class name', async () => {
         render(
-            <UnifiedCalendar {...defaultProps} className="custom-class" />
+            <UnifiedCalendar
+                {...defaultProps}
+                view="weekly"
+                className="custom-class"
+            />
         );
         await waitFor(() => {
-            expect(screen.getByText('Today').parentElement).toHaveClass(
-                'custom-class'
-            );
+            expect(
+                screen.getByLabelText(
+                    /Weekly Calendar for the week starting from/i
+                )
+            ).toHaveClass('custom-class');
         });
     });
 });

--- a/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.test.tsx
+++ b/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.test.tsx
@@ -64,4 +64,15 @@ describe('UnifiedCalendar', () => {
             expect(defaultProps.onViewChange).toHaveBeenCalledWith('monthly');
         });
     });
+
+    it('applies custom class name', async () => {
+        render(
+            <UnifiedCalendar {...defaultProps} className="custom-class" />
+        );
+        await waitFor(() => {
+            expect(screen.getByText('Today').parentElement).toHaveClass(
+                'custom-class'
+            );
+        });
+    });
 });

--- a/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.tsx
+++ b/ui/elements/Calendar/UnifiedCalendar/UnifiedCalendar.tsx
@@ -21,6 +21,7 @@ function UnifiedCalendar(props: UnifiedCalendarProps<any>) {
         loading = false,
         weeklyCalendarProps = {},
         monthlyCalendarProps = {},
+        className = '',
     } = props;
 
     const [viewType, setViewType] = useState(view);
@@ -78,6 +79,7 @@ function UnifiedCalendar(props: UnifiedCalendarProps<any>) {
                     onDateChange={setCurrentDate}
                     loading={loading}
                     {...monthlyCalendarProps}
+                    className={className}
                     renderDayItem={
                         typeof monthlyCalendarProps?.renderDayItem ===
                         'function'
@@ -123,6 +125,7 @@ function UnifiedCalendar(props: UnifiedCalendarProps<any>) {
                     onDateChange={setCurrentDate}
                     loading={loading}
                     {...weeklyCalendarProps}
+                    className={className}
                 />
             );
         default:

--- a/ui/elements/Calendar/UnifiedCalendar/types.ts
+++ b/ui/elements/Calendar/UnifiedCalendar/types.ts
@@ -96,6 +96,12 @@ export interface UnifiedCalendarProps<T> {
          */
         onPopOverClose?: () => void;
     };
+
+    /**
+     * Additional class name for the calendar wrapper
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface UnifiedCalendarHeaderProps {

--- a/ui/elements/Calendar/WeeklyCalendar/WeeklyCalendar.test.tsx
+++ b/ui/elements/Calendar/WeeklyCalendar/WeeklyCalendar.test.tsx
@@ -64,4 +64,15 @@ describe('WeeklyCalendar', () => {
             expect(defaultProps.onWeekChange).toHaveBeenCalledWith(0);
         });
     });
+
+    it('applies custom class name', async () => {
+        render(
+            <WeeklyCalendar {...defaultProps} className="custom-class" />
+        );
+        await waitFor(() => {
+            expect(
+                screen.getByLabelText(/Weekly Calendar for the week starting from/i)
+            ).toHaveClass('custom-class');
+        });
+    });
 });

--- a/ui/elements/Calendar/WeeklyCalendar/WeeklyCalendar.tsx
+++ b/ui/elements/Calendar/WeeklyCalendar/WeeklyCalendar.tsx
@@ -52,6 +52,7 @@ export default function WeeklyCalendar<T>(props: WeeklyCalendarProps<T>) {
         loading = false,
         defaultScrollHour = 8.5,
         shouldScrollToFirstEvent = true,
+        className = '',
     } = props;
 
     const [weekOffset, setWeekOffset] = useState(
@@ -209,6 +210,7 @@ export default function WeeklyCalendar<T>(props: WeeklyCalendarProps<T>) {
             aria-label={`Weekly Calendar for the week starting from ${getDateFullLabel(
                 currentWeek[0]
             )}`}
+            className={className}
         >
             <StyledCalendarHeader>
                 <StyledCalendarExternalHeaderContainer>

--- a/ui/elements/Calendar/WeeklyCalendar/types.ts
+++ b/ui/elements/Calendar/WeeklyCalendar/types.ts
@@ -92,6 +92,12 @@ export interface WeeklyCalendarProps<T = {}> {
      * @default true
      */
     shouldScrollToFirstEvent?: boolean;
+
+    /**
+     * Additional class name for the calendar wrapper
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface EventRendererProps<T = {}> {

--- a/ui/elements/FloatingActionButton/FloatingActionButton.test.tsx
+++ b/ui/elements/FloatingActionButton/FloatingActionButton.test.tsx
@@ -61,4 +61,11 @@ describe('FloatingActionButton Component', () => {
             'bottom: 10px'
         );
     });
+
+    it('applies custom class name', () => {
+        render(
+            <FloatingActionButton className="custom-class">+</FloatingActionButton>
+        );
+        expect(screen.getByTestId('floating-button')).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/FloatingActionButton/FloatingActionButton.tsx
+++ b/ui/elements/FloatingActionButton/FloatingActionButton.tsx
@@ -11,6 +11,7 @@ const FloatingActionButton = (props: FloatingActionButtonProps) => {
         onClick = () => {},
         sideOffset = '10px',
         bottomOffset = '10px',
+        className = '',
     } = props;
 
     const triggerRef = useRef<HTMLDivElement>(null);
@@ -22,6 +23,7 @@ const FloatingActionButton = (props: FloatingActionButtonProps) => {
             $position={position}
             $sideOffset={sideOffset}
             $bottomOffset={bottomOffset}
+            className={className}
             data-testid="floating-button"
         >
             {children}

--- a/ui/elements/FloatingActionButton/types.ts
+++ b/ui/elements/FloatingActionButton/types.ts
@@ -34,6 +34,12 @@ export interface FloatingActionButtonProps {
      * @default '10px'
      */
     bottomOffset?: string;
+
+    /**
+     * Additional class name for the floating button
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface StyledFloatingButtonProps extends StyledDivProps {

--- a/ui/elements/MultiSelectDropdown/MultiSelectDropdown.test.tsx
+++ b/ui/elements/MultiSelectDropdown/MultiSelectDropdown.test.tsx
@@ -261,4 +261,12 @@ describe('multi-select-dropdown', () => {
         const header = screen.getAllByRole('combobox')[0];
         expect(header).toHaveTextContent('All');
     });
+
+    it('applies custom class name', () => {
+        render(
+            <MultiSelectDropdown className="custom-class" options={options} />
+        );
+        const wrapper = screen.getByTestId('testid-multiselectdropdown-wrapper');
+        expect(wrapper).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/ui/elements/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -45,6 +45,7 @@ const MultiSelectDropdown = forwardRef<
         allOptionText = 'All',
         onOptionsChange = () => {},
         triggerComponent,
+        className = '',
     } = props;
 
     const [isOpened, setIsOpened] = useState(false);
@@ -124,6 +125,7 @@ const MultiSelectDropdown = forwardRef<
         <StyledDropdownWrapper
             ref={ref}
             data-testid="testid-multiselectdropdown-wrapper"
+            className={className}
         >
             {triggerComponent && (
                 <StyledDropdownTriggerWrapper

--- a/ui/elements/MultiSelectDropdown/types.ts
+++ b/ui/elements/MultiSelectDropdown/types.ts
@@ -77,6 +77,12 @@ export interface MultiSelectDropdownProps {
      * If not provided, the default trigger button will be rendered.
      */
     triggerComponent?: React.ReactNode;
+
+    /**
+     * Additional class name for the dropdown wrapper
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface DropdownListItemProps {

--- a/ui/elements/Placeholder/Placeholder.test.tsx
+++ b/ui/elements/Placeholder/Placeholder.test.tsx
@@ -30,4 +30,10 @@ describe('Placeholder Component', () => {
         expect(placeholder).toHaveStyle('margin: 10px');
         expect(placeholder).toHaveStyle('background-color: red');
     });
+
+    it('applies custom class name', () => {
+        render(<Placeholder className="custom-class" />);
+        const placeholder = screen.getByTestId('data-testid-placeholder');
+        expect(placeholder).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/Placeholder/Placeholder.tsx
+++ b/ui/elements/Placeholder/Placeholder.tsx
@@ -12,12 +12,14 @@ const Placeholder = forwardRef<HTMLDivElement, PlaceholderProps>(
             borderRadius = '0px',
             margin = '0px',
             backgroundColor = 'var(--bg-tertiary, #EDEFF3)',
+            className = '',
         } = props;
 
         return (
             <StyledPlaceholder
                 ref={ref}
                 data-testid="data-testid-placeholder"
+                className={className}
                 $width={width}
                 $height={height}
                 $border={border}

--- a/ui/elements/Placeholder/types.ts
+++ b/ui/elements/Placeholder/types.ts
@@ -36,6 +36,12 @@ export interface PlaceholderProps {
      * @default 'var(--bg-tertiary, #EDEFF3)'
      */
     backgroundColor?: string;
+
+    /**
+     * Additional class name for the placeholder
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface StyledPlaceholderProps extends StyledDivProps {

--- a/ui/elements/PopOver/PopOver.test.tsx
+++ b/ui/elements/PopOver/PopOver.test.tsx
@@ -59,4 +59,13 @@ describe('PopOver', () => {
         await new Promise((r) => setTimeout(r, 3000));
         expect(screen.queryByText('PopOver Content')).not.toBeInTheDocument();
     }, 5000);
+
+    it('applies custom class name', () => {
+        render(
+            <PopOver isOpen className="custom-class">
+                <div>PopOver Content</div>
+            </PopOver>
+        );
+        expect(document.querySelector('.custom-class')).toBeInTheDocument();
+    });
 });

--- a/ui/elements/PopOver/PopOver.tsx
+++ b/ui/elements/PopOver/PopOver.tsx
@@ -22,6 +22,7 @@ export default function PopOver(props: PopOverProps) {
         height,
         position,
         shouldFocusOnFirstElement = true,
+        className = '',
     } = props;
 
     const [adjustedOffset, setAdjustedOffset] = useState<PopOverOffset | null>(
@@ -278,6 +279,7 @@ export default function PopOver(props: PopOverProps) {
                         $offset={adjustedOffset}
                         {...motionProps}
                         variants={getMotionVariants(direction)}
+                        className={className}
                     >
                         <div
                             style={{

--- a/ui/elements/PopOver/types.ts
+++ b/ui/elements/PopOver/types.ts
@@ -92,6 +92,12 @@ export interface PopOverProps {
     position?: PopoverPosition;
 
     /**
+     * Additional class name for the popover container
+     * @default ''
+     */
+    className?: string;
+
+    /**
      * Should focus on the first element in the popover
      * @default true
      */

--- a/ui/elements/RangeInput/RangeInput.test.tsx
+++ b/ui/elements/RangeInput/RangeInput.test.tsx
@@ -76,4 +76,9 @@ describe('RangeInput Component', () => {
         expect(screen.getByText('0')).toBeInTheDocument();
         expect(screen.getByText('90')).toBeInTheDocument();
     });
+
+    it('applies custom class name', () => {
+        render(<RangeInput className="custom-class" />);
+        expect(screen.getByRole('form')).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/RangeInput/RangeInput.tsx
+++ b/ui/elements/RangeInput/RangeInput.tsx
@@ -16,6 +16,7 @@ const RangeInput = forwardRef<HTMLDivElement, RangeInputProps>((props, ref) => {
         value = { min: 0, max: 100 },
         onChange = () => {},
         width = '100%',
+        className = '',
     } = props;
 
     const [minInput, setMinInput] = useState(value.min || minValue);
@@ -41,7 +42,12 @@ const RangeInput = forwardRef<HTMLDivElement, RangeInputProps>((props, ref) => {
     }, [finalMinInput, finalMaxInput]);
 
     return (
-        <StyledRangeInputContainer ref={ref} $width={width} role="form">
+        <StyledRangeInputContainer
+            ref={ref}
+            $width={width}
+            role="form"
+            className={className}
+        >
             <StyledValuesContainer>
                 <div>{finalMinInput}</div>
                 <div>{finalMaxInput}</div>

--- a/ui/elements/RangeInput/types.ts
+++ b/ui/elements/RangeInput/types.ts
@@ -41,6 +41,12 @@ export interface RangeInputProps {
      * @default '100%'
      */
     width?: string;
+
+    /**
+     * Additional class name for the range input container
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface StyledRangeInputContainerProps extends StyledDivProps {

--- a/ui/elements/SelectDropdown/SelectDropdown.test.tsx
+++ b/ui/elements/SelectDropdown/SelectDropdown.test.tsx
@@ -107,4 +107,10 @@ describe('SelectDropdown Component', () => {
         await new Promise((r) => setTimeout(r, 3000));
         expect(screen.queryAllByRole('option')).toHaveLength(0);
     }, 5000);
+
+    it('applies custom class name', () => {
+        render(<SelectDropdown options={options} className="custom-class" />);
+        const wrapper = screen.getByRole('combobox');
+        expect(wrapper).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/SelectDropdown/SelectDropdown.tsx
+++ b/ui/elements/SelectDropdown/SelectDropdown.tsx
@@ -33,6 +33,7 @@ const SelectDropdown = forwardRef<HTMLSelectElement, SelectDropdownProps>(
             noOptionsText = '-- No options available --',
             triggerComponent,
             width,
+            className = '',
         } = props;
 
         const [isOpened, setIsOpened] = useState(false);
@@ -49,7 +50,11 @@ const SelectDropdown = forwardRef<HTMLSelectElement, SelectDropdownProps>(
         );
 
         return (
-            <StyledSelectDropdownWrapper ref={ref} role="combobox">
+            <StyledSelectDropdownWrapper
+                ref={ref}
+                role="combobox"
+                className={className}
+            >
                 {triggerComponent && (
                     <StyledSelectDropdownTriggerWrapper
                         ref={triggerRef}

--- a/ui/elements/SelectDropdown/types.ts
+++ b/ui/elements/SelectDropdown/types.ts
@@ -77,6 +77,12 @@ export interface SelectDropdownProps {
      * @default max-content
      */
     width?: string | null;
+
+    /**
+     * Additional class name for the dropdown wrapper
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface StyledSelectDropdownWrapperProps extends StyledSelectProps {}

--- a/ui/elements/Tabs/Tabs.test.tsx
+++ b/ui/elements/Tabs/Tabs.test.tsx
@@ -31,4 +31,12 @@ describe('Tabs Component', () => {
         expect(screen.getByText('Text 1')).toBeInTheDocument();
         expect(screen.getByText('Text 2')).toBeInTheDocument();
     });
+
+    it('applies custom class name', () => {
+        render(
+            <Tabs tabItems={['Item1', 'Item2']} className="custom-class" />
+        );
+        const tablist = screen.getByRole('tablist');
+        expect(tablist).toHaveClass('custom-class');
+    });
 });

--- a/ui/elements/Tabs/Tabs.tsx
+++ b/ui/elements/Tabs/Tabs.tsx
@@ -33,6 +33,7 @@ function Tabs(props: TabProps) {
         <StyledTabContainer
             backgroundColor={backgroundColor}
             className={className}
+            role="tablist"
         >
             {tabItems?.map((item, idx) => (
                 <StyledTabItemContainer

--- a/ui/elements/Tabs/Tabs.tsx
+++ b/ui/elements/Tabs/Tabs.tsx
@@ -16,6 +16,7 @@ function Tabs(props: TabProps) {
         focusBackgroundColor = null,
         focusColor = null,
         color = null,
+        className = '',
     } = props;
 
     const [activeTab, setActiveTab] = useState(initialActiveTab);
@@ -29,7 +30,10 @@ function Tabs(props: TabProps) {
     }, [activeTab]);
 
     return (
-        <StyledTabContainer backgroundColor={backgroundColor}>
+        <StyledTabContainer
+            backgroundColor={backgroundColor}
+            className={className}
+        >
             {tabItems?.map((item, idx) => (
                 <StyledTabItemContainer
                     onClick={() => handleItemClick(idx)}

--- a/ui/elements/Tabs/types.ts
+++ b/ui/elements/Tabs/types.ts
@@ -65,7 +65,8 @@ export interface TabProps {
     color?: string;
 
     /**
-     *  Default Color
+     * Additional class name for the tabs container
+     * @default ''
      */
     className?: string;
 }

--- a/ui/elements/Tabs/types.ts
+++ b/ui/elements/Tabs/types.ts
@@ -8,6 +8,12 @@ export interface StyledTabContainerProps extends StyledDivProps {
 
 export interface StyledTextProps extends StyledDivProps {
     color?: string;
+
+    /**
+     * Additional class name for the tabs container
+     * @default ''
+     */
+    className?: string;
 }
 
 export interface StyledTabItemContainerProps

--- a/ui/elements/Tabs/types.ts
+++ b/ui/elements/Tabs/types.ts
@@ -63,4 +63,9 @@ export interface TabProps {
      *  Default Color
      */
     color?: string;
+
+    /**
+     *  Default Color
+     */
+    className?: string;
 }

--- a/ui/elements/Typography/Typography.test.tsx
+++ b/ui/elements/Typography/Typography.test.tsx
@@ -7,7 +7,11 @@ import Typography from './Typography';
 
 describe('Typography', () => {
     it('applies custom class name', () => {
-        render(<Typography className="custom-class">Text</Typography>);
+        render(
+            <Typography variant="paragraph-md-p1" className="custom-class">
+                Text
+            </Typography>
+        );
         const text = screen.getByText('Text');
         expect(text).toHaveClass('custom-class');
     });

--- a/ui/elements/Typography/Typography.test.tsx
+++ b/ui/elements/Typography/Typography.test.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import Typography from './Typography';
+
+describe('Typography', () => {
+    it('applies custom class name', () => {
+        render(<Typography className="custom-class">Text</Typography>);
+        const text = screen.getByText('Text');
+        expect(text).toHaveClass('custom-class');
+    });
+});

--- a/ui/elements/Typography/Typography.tsx
+++ b/ui/elements/Typography/Typography.tsx
@@ -23,6 +23,7 @@ const Typography = ({
     textTransform = null,
     fontSize = null,
     children = '',
+    className = '',
 }: TypographyProps) => {
     const asType =
         as === TYPOGRAPHY_AS_ENUM.AUTO
@@ -36,6 +37,7 @@ const Typography = ({
             textAlign={textAlign}
             textTransform={textTransform}
             fontSize={fontSize}
+            className={className}
         >
             {children}
         </StyledTypography>

--- a/ui/elements/Typography/types.ts
+++ b/ui/elements/Typography/types.ts
@@ -112,6 +112,12 @@ export interface TypographyProps {
     fontSize?: string;
 
     /**
+     * Additional class name for the typography element
+     * @default ''
+     */
+    className?: string;
+
+    /**
      * Children of the component
      * */
     children: React.ReactNode;

--- a/ui/elements/Typography/types.ts
+++ b/ui/elements/Typography/types.ts
@@ -62,6 +62,12 @@ export interface StyledTypographyInterface {
     textAlign?: string;
     textTransform?: string;
     fontSize?: string;
+
+    /**
+     * Additional class name for the typography element
+     * @default ''
+     */
+    className?: string;
     children: React.ReactNode;
 }
 


### PR DESCRIPTION
## Description

- Added `className` support to multiple UI components like `DropdownMenuHeader`, `Tabs`, etc.
- Created/updated test cases to ensure that custom classes are applied properly.
- Mocked `window.scrollTo` in test files to bypass `jsdom` limitations.
- Minor test cleanup to handle duplicate element selection errors in `DropdownMenu`.

## Type of Change

- [x] ✅ Test updates  
- [x] ♻️ Code refactor (no functional changes)  
- [ ] 🐛 Bug fix  
- [ ] ✨ New feature  
- [ ] 📚 Documentation update  
- [ ] 🎨 Style update  
- [ ] 💥 Breaking change  
- [ ] 🔄 Other (please describe):

## Related Issues

Fixes #219 

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
  - Incorrect: ❌ Dependency version update
  - Correct: ✅ Add className support to DropdownMenuHeader
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new TypeScript warnings
- [x] My changes do not hide eslint warnings unnecessarily
- [x] My pull request maintains linear history with the master branch to ensure that new changes are compatible with latest code.

