### PR TITLE
Fix: Add troubleshooting steps for submodule setup (SSH → HTTPS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ npm install
 git submodule init
 git submodule update --recursive
 
+# if found error after run the above cmd try this below one
+
+# Change submodule URL from SSH → HTTPS
+git submodule set-url iconland https://github.com/Newton-School/iconland.git
+git submodule update --init --recursive
+
 # Build icons (required when running for first time)
 npm run build-icons
 


### PR DESCRIPTION
## Description
When i setting up the repository,  i encounter the following error during submodule initialization:
```
git@github.com: Permission denied (publickey)
fatal: Could not read from remote repository
```
### Solution :
- This happens because the iconland submodule uses an SSH URL by default, which requires GitHub SSH keys.
To make setup smoother for all contributors, I updated the README with troubleshooting steps to switch the submodule URL to HTTPS:

```
git submodule set-url iconland https://github.com/Newton-School/iconland.git
git submodule update --init --recursive
```


## Type of Change
- [x] 📚 Documentation update

