### PR TITLE
Simplify TextField & TextArea errorMessage handling to show when provided

### DIFF
--- a/stories/elements/Form/TextArea/index.stories.tsx
+++ b/stories/elements/Form/TextArea/index.stories.tsx
@@ -23,7 +23,6 @@ Default.args = {
     label: 'Example Label',
     isRequired: false,
     placeholder: 'This is placeholder text...',
-    validationMessage: 'This is a validation message',
     helpMessage: 'This is a help message',
     errorMessage: 'This is an error message',
     maxLength: 100,

--- a/stories/elements/Form/TextField/index.stories.tsx
+++ b/stories/elements/Form/TextField/index.stories.tsx
@@ -25,7 +25,6 @@ Default.args = {
     label: 'Example Label',
     isRequired: false,
     placeholder: 'This is placeholder text...',
-    validationMessage: 'This is a validation message',
     helpMessage: 'This is a help message',
     errorMessage: 'This is an error message',
     maxLength: 100,

--- a/ui/elements/Form/TextArea/TextArea.test.tsx
+++ b/ui/elements/Form/TextArea/TextArea.test.tsx
@@ -33,22 +33,6 @@ describe('TextArea Component', () => {
         expect(defaultProps.onChange).toHaveBeenCalledWith(expect.any(Object));
     });
 
-    test('displays validation error message if input is invalid', () => {
-        const propsWithValidation = {
-            ...defaultProps,
-            isRequired: true,
-            validationMessage: 'This field is required.',
-        };
-
-        render(<TextArea {...propsWithValidation} />);
-        const textarea = screen.getByRole('textbox');
-
-        fireEvent.change(textarea, { target: { value: '' } });
-        fireEvent.blur(textarea);
-
-        expect(screen.getByText('This field is required.')).toBeInTheDocument();
-    });
-
     test('disables the TextArea when isDisabled is true', () => {
         render(<TextArea {...defaultProps} isDisabled />);
         const textarea = screen.getByRole('textbox');
@@ -71,17 +55,13 @@ describe('TextArea Component', () => {
         expect(screen.getByText(/5\/10/)).toBeInTheDocument();
     });
 
-    test('renders error message when input exceeds maxLength', () => {
+    test('renders error message when provided', () => {
         const propsWithValidation = {
             ...defaultProps,
-            maxLength: 5,
             errorMessage: 'Too many characters!',
         };
 
         render(<TextArea {...propsWithValidation} />);
-        const textarea = screen.getByRole('textbox');
-
-        fireEvent.change(textarea, { target: { value: 'Too long text' } });
 
         expect(screen.getByText('Too many characters!')).toBeInTheDocument();
     });

--- a/ui/elements/Form/TextArea/TextArea.tsx
+++ b/ui/elements/Form/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { ErrorMessage } from '../ErrorMessage';
 import { HelpMessage } from '../HelpMessage';
@@ -13,7 +13,6 @@ const TextArea = (props: TextAreaProps) => {
         label,
         size = 'medium',
         placeholder,
-        validationMessage,
         helpMessage,
         errorMessage,
         maxLength,
@@ -31,16 +30,6 @@ const TextArea = (props: TextAreaProps) => {
         className,
     } = props;
 
-    const getIsValid = (targetValue: string) => {
-        const satisfiesMinLength = isRequired ? targetValue.length > 0 : true;
-        const satisfiesMaxLength = maxLength
-            ? targetValue.length <= maxLength
-            : true;
-        return satisfiesMinLength && satisfiesMaxLength;
-    };
-
-    const [isInputValid, setIsInputValid] = useState(getIsValid(value));
-
     const handleInputClick = (
         event: React.MouseEvent<HTMLTextAreaElement, MouseEvent>
     ) => {
@@ -51,8 +40,6 @@ const TextArea = (props: TextAreaProps) => {
         event: React.ChangeEvent<HTMLTextAreaElement>
     ) => {
         onChange(event);
-        const isValid = getIsValid(event.target.value);
-        setIsInputValid(isValid);
     };
 
     const handleInputBlur = (event: React.FocusEvent<HTMLTextAreaElement>) => {
@@ -96,9 +83,7 @@ const TextArea = (props: TextAreaProps) => {
                     {helpMessage}
                 </HelpMessage>
             )}
-            {!isInputValid && (errorMessage || validationMessage) && (
-                <ErrorMessage>{errorMessage || validationMessage}</ErrorMessage>
-            )}
+            {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
         </StyledTextAreaFieldContainer>
     );
 };

--- a/ui/elements/Form/TextArea/types.ts
+++ b/ui/elements/Form/TextArea/types.ts
@@ -37,11 +37,6 @@ export interface TextAreaProps {
     placeholder?: string;
 
     /**
-     * The validation message to display when the input field is invalid.
-     */
-    validationMessage?: string;
-
-    /**
      * The input value.
      * @default ''
      */

--- a/ui/elements/Form/TextField/TextField.tsx
+++ b/ui/elements/Form/TextField/TextField.tsx
@@ -27,7 +27,6 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
         type = 'text',
         inputMode = 'text',
         pattern,
-        validationMessage,
         helpMessage,
         errorMessage,
         maxLength,
@@ -79,24 +78,12 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
         }
     }, [adornments?.start, adornments?.end]);
 
-    const getIsValid = (targetValue: string) => {
-        const satisfiesMinLength = isRequired ? targetValue.length > 0 : true;
-        const satisfiesMaxLength = maxLength
-            ? targetValue.length <= maxLength
-            : true;
-        return satisfiesMinLength && satisfiesMaxLength;
-    };
-
-    const [isInputValid, setIsInputValid] = useState(getIsValid(value));
-
     const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
         onClick(event);
     };
 
     const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         onChange(event);
-        const isValid = getIsValid(event.target.value);
-        setIsInputValid(isValid);
     };
 
     const handleInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -160,9 +147,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
                 {helpMessage}
             </HelpMessage>
 
-            {(!isInputValid || errorMessage) && validationMessage && (
-                <ErrorMessage>{errorMessage || validationMessage}</ErrorMessage>
-            )}
+            {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
         </StyledTextInputFieldContainer>
     );
 });

--- a/ui/elements/Form/TextField/types.ts
+++ b/ui/elements/Form/TextField/types.ts
@@ -88,11 +88,6 @@ export interface TextFieldProps {
     step?: number;
 
     /**
-     * The validation message to display when the input field is invalid.
-     */
-    validationMessage?: string;
-
-    /**
      * The input value.
      * @default ''
      */

--- a/ui/elements/Form/useForm/FormField.tsx
+++ b/ui/elements/Form/useForm/FormField.tsx
@@ -64,7 +64,6 @@ const FormField = forwardRef<HTMLDivElement, FormFieldProps>((props, ref) => {
                                 });
                             }
                         }}
-                        validationMessage={error}
                         errorMessage={error}
                         color={error ? 'error' : 'brand'}
                     />


### PR DESCRIPTION
## Description

This PR simplifies the error message handling in TextField and TextArea components by removing the validationMessage prop and internal validation logic, consolidating error display to only show when errorMessage is provided.

Removed validationMessage prop and internal validation state from both TextField and TextArea components
Simplified error message rendering to display only when errorMessage is provided
Updated tests and stories to reflect the simplified API

## Type of Change

- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Test updates

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
  - Incorrect: ❌ Dependency version update
  - Correct: ✅ Update version of framer-motion
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new TypeScript warnings
- [x] My changes does not hide eslint warnings un-necessarily
- [x] My pull request maintains linear history with the master branch to ensure that new changes are compatible with latest code.
