### PR TITLE
fix: use transient props for non-DOM props in styled-components

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -53,8 +53,8 @@ export interface StyledInputProps
 export interface StyledLabelProps
     extends React.LabelHTMLAttributes<HTMLLabelElement> {
     ref?: React.Ref<HTMLLabelElement>;
-    isRequired?: boolean;
-    isDisabled?: boolean;
+    $isRequired?: boolean;
+    $isDisabled?: boolean;
     color?: `${TEXT_COLORS}`;
 }
 

--- a/ui/elements/Button/Button.styles.ts
+++ b/ui/elements/Button/Button.styles.ts
@@ -38,8 +38,8 @@ export const StyledButton = styled.button<ButtonComponentProps>`
         cursor: not-allowed;
     }
 
-    ${({ size, isIconButton }) => {
-        if (!isIconButton) {
+    ${({ size, $isIconButton }) => {
+        if (!$isIconButton) {
             return css`
                 ${BUTTON_SIZE_STYLES_MAPPING[size]}
             `;
@@ -50,20 +50,20 @@ export const StyledButton = styled.button<ButtonComponentProps>`
         `;
     }}
 
-    ${({ fullWidth }) =>
-        fullWidth &&
+    ${({ $fullWidth }) =>
+        $fullWidth &&
         css`
             width: 100%;
         `}
 
-    ${({ isLoading }) =>
-        isLoading &&
+    ${({ $isLoading }) =>
+        $isLoading &&
         css`
             cursor: progress;
         `}
 
-    ${({ iconPosition }) =>
-        iconPosition === 'right' &&
+    ${({ $iconPosition }) =>
+        $iconPosition === 'right' &&
         css`
             flex-direction: row-reverse;
         `}

--- a/ui/elements/Button/Button.tsx
+++ b/ui/elements/Button/Button.tsx
@@ -54,13 +54,13 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
             onClick={handleClick}
             className={classes}
             style={style}
-            isLoading={loading}
+            $isLoading={loading}
             disabled={disabled || loading}
             variant={variant}
             $color={color as ButtonColors}
             size={size}
-            fullWidth={fullWidth}
-            iconPosition={iconPosition}
+            $fullWidth={fullWidth}
+            $iconPosition={iconPosition}
             type={type}
             title={tooltip}
             tabIndex={tabIndex}

--- a/ui/elements/Button/IconButton.tsx
+++ b/ui/elements/Button/IconButton.tsx
@@ -53,12 +53,12 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
                 onClick={handleClick}
                 className={classes}
                 style={style}
-                isLoading={loading}
+                $isLoading={loading}
                 disabled={disabled || loading}
                 variant={variant}
                 $color={color}
                 size={size}
-                fullWidth={fullWidth}
+                $fullWidth={fullWidth}
                 type={type}
                 role="button"
                 aria-label={ariaLabel || icon}
@@ -66,7 +66,7 @@ const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
                 tabIndex={tabIndex}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
-                isIconButton
+                $isIconButton
                 $showAnimationOnClick={showAnimationOnClick}
                 {...buttonProps}
                 data-testid="testid-iconbutton"

--- a/ui/elements/Button/types.ts
+++ b/ui/elements/Button/types.ts
@@ -276,14 +276,14 @@ export interface ButtonComponentProps extends StyledButtonProps {
     size?: ButtonSizes;
     icon?: string | number;
     iconSize?: string;
-    iconPosition?: 'left' | 'right';
+    $iconPosition?: 'left' | 'right';
     className?: string;
     disabled?: boolean;
-    isLoading?: boolean;
+    $isLoading?: boolean;
     style?: React.CSSProperties;
     onClick?: (e?: any) => void;
-    fullWidth?: boolean;
-    isIconButton?: boolean;
+    $fullWidth?: boolean;
+    $isIconButton?: boolean;
     children?: React.ReactNode;
     ref?: React.Ref<HTMLButtonElement>;
     type?: ButtonTypeAttribute;

--- a/ui/elements/Calendar/MonthlyCalendarEvent/MonthlyCalendar.styles.ts
+++ b/ui/elements/Calendar/MonthlyCalendarEvent/MonthlyCalendar.styles.ts
@@ -1,11 +1,11 @@
 import styled, { css } from 'styled-components';
 
 import {
-    MonthlyCalendarEventProps,
+    StyledMonthlyCalendarEventProps,
     StyledMonthlyCalendarEventTextProps,
 } from './types';
 
-export const StyledMonthlyCalendarEvent = styled.div<MonthlyCalendarEventProps>`
+export const StyledMonthlyCalendarEvent = styled.div<StyledMonthlyCalendarEventProps>`
     cursor: pointer;
     box-sizing: border-box;
     font-family: var(--font-family, 'Mona Sans');
@@ -19,8 +19,8 @@ export const StyledMonthlyCalendarEvent = styled.div<MonthlyCalendarEventProps>`
     height: ${({ height }) => height || '16px'};
     padding: 2px;
 
-    ${({ isActive, width, height }) =>
-        isActive &&
+    ${({ $isActive, width, height }) =>
+        $isActive &&
         css`
             border: 2px solid var(--text-emphasis-white-default, #ffffff);
             box-shadow: 0px 4px 32px var(--spacing-0px, 0px) rgba(0, 0, 0, 0.32);

--- a/ui/elements/Calendar/MonthlyCalendarEvent/MonthlyCalendarEvent.tsx
+++ b/ui/elements/Calendar/MonthlyCalendarEvent/MonthlyCalendarEvent.tsx
@@ -12,11 +12,30 @@ const MonthlyCalendarEvent = forwardRef<
     HTMLDivElement,
     MonthlyCalendarEventProps
 >((props, ref) => {
-    const { eventTime, eventTitle, eventTitleColor, eventTimeColor } = props;
+    const {
+        eventTime,
+        eventTitle,
+        eventTitleColor,
+        eventTimeColor,
+        backgroundColor,
+        borderRadius,
+        width,
+        height,
+        $isActive,
+        ...rest
+    } = props;
     const eventTimeString = get12HourFormatFromDate(eventTime);
 
     return (
-        <StyledMonthlyCalendarEvent {...props} ref={ref}>
+        <StyledMonthlyCalendarEvent
+            ref={ref}
+            backgroundColor={backgroundColor}
+            borderRadius={borderRadius}
+            width={width}
+            height={height}
+            $isActive={$isActive}
+            {...rest}
+        >
             <StyledMonthlyCalendarEventText color={eventTimeColor}>
                 {eventTimeString}
             </StyledMonthlyCalendarEventText>

--- a/ui/elements/Calendar/MonthlyCalendarEvent/types.ts
+++ b/ui/elements/Calendar/MonthlyCalendarEvent/types.ts
@@ -53,7 +53,15 @@ export interface MonthlyCalendarEventProps extends StyledDivProps {
      * Whether the calendar event is active.
      * @default false
      */
-    isActive?: boolean;
+    $isActive?: boolean;
+}
+
+export interface StyledMonthlyCalendarEventProps {
+    backgroundColor?: string;
+    borderRadius?: string;
+    width?: string;
+    height?: string;
+    $isActive?: boolean;
 }
 
 export interface StyledMonthlyCalendarEventTextProps extends StyledDivProps {

--- a/ui/elements/Chip/Chip.styles.ts
+++ b/ui/elements/Chip/Chip.styles.ts
@@ -31,29 +31,29 @@ export const StyledChipDiv = styled.div<StyledChip>`
         css`
             ${CHIP_FONT_SIZE_MAPPING[size]}
         `}
-    ${({ hasBorder, borderColor }) =>
-        hasBorder &&
+    ${({ $hasBorder, $borderColor }) =>
+        $hasBorder &&
         css`
             border: 1px solid;
-            border-color: ${borderColor};
+            border-color: ${$borderColor};
         `}
-    ${({ textColor }) =>
-        textColor &&
+    ${({ $textColor }) =>
+        $textColor &&
         css`
-            color: ${textColor};
+            color: ${$textColor};
         `}
-    ${({ backgroundColor }) =>
-        backgroundColor &&
+    ${({ $backgroundColor }) =>
+        $backgroundColor &&
         css`
-            background: ${backgroundColor};
+            background: ${$backgroundColor};
         `}
-    ${({ rounded }) =>
-        rounded &&
+    ${({ $rounded }) =>
+        $rounded &&
         css`
             border-radius: 100px;
         `}
-    ${({ iconPosition }) =>
-        iconPosition === 'right' &&
+    ${({ $iconPosition }) =>
+        $iconPosition === 'right' &&
         css`
             flex-direction: row-reverse;
         `}

--- a/ui/elements/Chip/Chip.tsx
+++ b/ui/elements/Chip/Chip.tsx
@@ -30,12 +30,12 @@ const Chip = forwardRef<HTMLDivElement, ChipProps>(
             style={style}
             variant={variant}
             size={size}
-            hasBorder={hasBorder}
-            textColor={textColor}
-            backgroundColor={backgroundColor}
-            borderColor={borderColor}
-            rounded={rounded}
-            iconPosition={iconPosition}
+            $hasBorder={hasBorder}
+            $textColor={textColor}
+            $backgroundColor={backgroundColor}
+            $borderColor={borderColor}
+            $rounded={rounded}
+            $iconPosition={iconPosition}
         >
             {icon && <Icon name={icon} color={iconColor} size={iconSize} />}
             <StyledChipText

--- a/ui/elements/Chip/types.ts
+++ b/ui/elements/Chip/types.ts
@@ -112,11 +112,11 @@ export interface ChipProps {
 export interface StyledChip extends StyledDivProps {
     variant?: ChipVariants;
     size?: ChipSizes;
-    hasBorder?: boolean;
-    textColor?: string | null;
-    backgroundColor?: string | null;
-    borderColor?: string | null;
-    rounded?: boolean;
+    $hasBorder?: boolean;
+    $textColor?: string | null;
+    $backgroundColor?: string | null;
+    $borderColor?: string | null;
+    $rounded?: boolean;
     ref?: React.Ref<HTMLDivElement>;
-    iconPosition?: ButtonIconPositions;
+    $iconPosition?: ButtonIconPositions;
 }

--- a/ui/elements/Form/Checkbox/Checkbox.styles.ts
+++ b/ui/elements/Form/Checkbox/Checkbox.styles.ts
@@ -90,8 +90,8 @@ export const StyledCheckboxLabel = styled(Label)`
     letter-spacing: 0.1px;
     cursor: pointer;
 
-    ${({ isDisabled }: StyledLabelProps) =>
-        isDisabled &&
+    ${({ $isDisabled }: StyledLabelProps) =>
+        $isDisabled &&
         css`
             color: var(--text-emphasis-primary-disabled, #8c95a6);
         `};

--- a/ui/elements/Form/Checkbox/Checkbox.tsx
+++ b/ui/elements/Form/Checkbox/Checkbox.tsx
@@ -102,8 +102,8 @@ const Checkbox: React.FC<CheckboxProps> = ({
                 {label && (
                     <StyledCheckboxLabel
                         name={`checkbox-${id}`}
-                        isRequired={isRequired}
-                        isDisabled={isDisabled}
+                        $isRequired={isRequired}
+                        $isDisabled={isDisabled}
                         id={`checkbox-label-${id}`}
                     >
                         {label}

--- a/ui/elements/Form/Label/index.tsx
+++ b/ui/elements/Form/Label/index.tsx
@@ -8,6 +8,7 @@ export const Label = (props: LabelProps) => {
         name,
         color = 'secondary',
         isRequired,
+        isDisabled,
         children,
         className,
         ...rest
@@ -16,7 +17,8 @@ export const Label = (props: LabelProps) => {
     return (
         <StyledLabel
             htmlFor={name}
-            isRequired={isRequired}
+            $isRequired={isRequired}
+            $isDisabled={isDisabled}
             className={className}
             color={color}
             {...rest}

--- a/ui/elements/Form/RadioButton/RadioButton.styles.ts
+++ b/ui/elements/Form/RadioButton/RadioButton.styles.ts
@@ -130,8 +130,8 @@ export const StyledRadioButtonLabel = styled(
         `;
     }}
 
-    ${({ isDisabled }: StyledLabelProps) =>
-        isDisabled &&
+    ${({ $isDisabled }: StyledLabelProps) =>
+        $isDisabled &&
         css`
             color: var(--text-emphasis-primary-disabled, #8c95a6);
             cursor: not-allowed;

--- a/ui/elements/Form/RadioButton/RadioButton.tsx
+++ b/ui/elements/Form/RadioButton/RadioButton.tsx
@@ -55,8 +55,8 @@ const RadioButton = (props: RadioButtonProps) => {
                 {label && (
                     <StyledRadioButtonLabel
                         name={`radio-button-${id}`}
-                        isRequired={isRequired}
-                        isDisabled={isDisabled}
+                        $isRequired={isRequired}
+                        $isDisabled={isDisabled}
                         $size={size}
                         color={color === 'brand' ? 'primary' : color}
                     >

--- a/ui/elements/Form/index.styles.tsx
+++ b/ui/elements/Form/index.styles.tsx
@@ -12,8 +12,8 @@ export const StyledLabel = styled.label<StyledLabelProps>`
     letter-spacing: 0.048px;
     font-family: var(--font-family);
 
-    ${({ isRequired }) =>
-        isRequired &&
+    ${({ $isRequired }) =>
+        $isRequired &&
         css`
             &::after {
                 content: '*';
@@ -28,8 +28,8 @@ export const StyledLabel = styled.label<StyledLabelProps>`
         `;
     }}
 
-    ${({ isDisabled }) =>
-        isDisabled &&
+    ${({ $isDisabled }) =>
+        $isDisabled &&
         css`
             color: var(--text-emphasis-primary-disabled, #8c95a6);
             cursor: not-allowed;

--- a/ui/elements/Form/types.ts
+++ b/ui/elements/Form/types.ts
@@ -18,6 +18,16 @@ export interface LabelProps extends StyledLabelProps {
     color?: FormTextColors;
 
     /**
+     * Whether the field is required. Adds an asterisk to the label.
+     */
+    isRequired?: boolean;
+
+    /**
+     * Whether the field is disabled. Changes the label color.
+     */
+    isDisabled?: boolean;
+
+    /**
      * The content of the label.
      */
     children: React.ReactNode;

--- a/ui/elements/Tabs/Tabs.styles.ts
+++ b/ui/elements/Tabs/Tabs.styles.ts
@@ -19,10 +19,10 @@ export const StyledTabContainer = styled.div<StyledTabContainerProps>`
     background: var(--bg-subtle-secondary-default, #f6f7f9);
     font-family: var(--font-family, 'Mona Sans');
 
-    ${({ backgroundColor }) =>
-        backgroundColor &&
+    ${({ $backgroundColor }) =>
+        $backgroundColor &&
         css`
-            background: ${backgroundColor};
+            background: ${$backgroundColor};
         `}
 `;
 
@@ -38,10 +38,10 @@ export const StyledTabItemContainer = styled.div<StyledTabItemContainerProps>`
     flex: 1;
     color: var(--text-emphasis-primary-default, #16191d);
 
-    ${({ backgroundColor }) =>
-        backgroundColor &&
+    ${({ $backgroundColor }) =>
+        $backgroundColor &&
         css`
-            background: ${backgroundColor};
+            background: ${$backgroundColor};
         `}
 
     ${({ color }) =>
@@ -50,12 +50,12 @@ export const StyledTabItemContainer = styled.div<StyledTabItemContainerProps>`
             color: ${color};
         `}
 
-    ${({ isActive, focusColor, focusBackgroundColor }) =>
-        isActive &&
+    ${({ $isActive, $focusColor, $focusBackgroundColor }) =>
+        $isActive &&
         css`
-            background: ${focusBackgroundColor ||
+            background: ${$focusBackgroundColor ||
             'var(--bg-subtle-primary-default, #ffffff)'};
-            color: ${focusColor ||
+            color: ${$focusColor ||
             'var(--text-emphasis-brand-default, #0673f9)'};
         `}
 `;

--- a/ui/elements/Tabs/Tabs.tsx
+++ b/ui/elements/Tabs/Tabs.tsx
@@ -31,17 +31,17 @@ function Tabs(props: TabsProps) {
 
     return (
         <StyledTabContainer
-            backgroundColor={backgroundColor}
+            $backgroundColor={backgroundColor}
             className={className}
             role="tablist"
         >
             {tabItems?.map((item, idx) => (
                 <StyledTabItemContainer
                     onClick={() => handleItemClick(idx)}
-                    isActive={activeTab === idx}
+                    $isActive={activeTab === idx}
                     color={color}
-                    focusBackgroundColor={focusBackgroundColor}
-                    focusColor={focusColor}
+                    $focusBackgroundColor={focusBackgroundColor}
+                    $focusColor={focusColor}
                     key={typeof item === 'string' ? item : String(item) + idx}
                 >
                     {typeof item === 'string' ? (

--- a/ui/elements/Tabs/types.ts
+++ b/ui/elements/Tabs/types.ts
@@ -3,7 +3,7 @@ import React from 'react';
 import { StyledDivProps } from '../../../common/types';
 
 export interface StyledTabContainerProps extends StyledDivProps {
-    backgroundColor?: string;
+    $backgroundColor?: string;
 }
 
 export interface StyledTextProps extends StyledDivProps {
@@ -18,11 +18,11 @@ export interface StyledTextProps extends StyledDivProps {
 
 export interface StyledTabItemContainerProps
     extends React.HTMLAttributes<HTMLDivElement> {
-    isActive?: boolean;
-    backgroundColor?: string;
-    focusColor?: string;
+    $isActive?: boolean;
+    $backgroundColor?: string;
+    $focusColor?: string;
     color?: string;
-    focusBackgroundColor?: string;
+    $focusBackgroundColor?: string;
 }
 
 export interface TabsProps {


### PR DESCRIPTION
- Convert Button props to transient: fullWidth, iconPosition, isLoading, isIconButton
- Convert Chip props to transient: hasBorder, textColor, backgroundColor, borderColor, rounded, iconPosition
- Convert Tabs props to transient: isActive, focusBackgroundColor, focusColor, backgroundColor
- Convert MonthlyCalendarEvent: prevent eventTitle/eventTime from DOM, convert isActive to transient
- Convert Form component props to transient: isRequired, isDisabled

This eliminates React DOM warnings for invalid props on DOM elements.

Fixes #221
