### PR TITLE
Bump version to 3.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.3.12",
+    "version": "3.3.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@newtonschool/grauity",
-            "version": "3.3.12",
+            "version": "3.3.13",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.3.12",
+    "version": "3.3.13",
     "description": "Design System for Newton School",
     "keywords": [
         "Newton School",


### PR DESCRIPTION
## Summary
- Bumps package version from 3.3.12 to 3.3.13 in `package.json` and `package-lock.json`

## Test plan
- [ ] Verify version is 3.3.13 in both `package.json` and `package-lock.json`
- [ ] Merge and create GitHub release `v3.3.13` to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)