### PR TITLE
perf(motion): lazy-load framer-motion via LazyMotion + `m` (~12KB gzip/component)

### DIFF
--- a/__mocks__/framer-motion.tsx
+++ b/__mocks__/framer-motion.tsx
@@ -16,6 +16,24 @@ export const motion = {
     button: createMotionComponent('button'),
 };
 
+// `m` is the lightweight, lazy-feature variant of `motion` (used with
+// LazyMotion). For tests it behaves identically to `motion`.
+export const m = motion;
+
+// LazyMotion is a feature-provider; in tests it just renders its children.
+// Accepts and ignores the framer props callers pass (e.g. `features`, `strict`)
+// via an index signature so they don't need to be enumerated as named props.
+export const LazyMotion = ({
+    children,
+}: {
+    children?: React.ReactNode;
+    [key: string]: unknown;
+}) => <>{children}</>;
+
+// Feature bundles passed to <LazyMotion features={...}> — inert in tests.
+export const domAnimation = {};
+export const domMax = {};
+
 export const AnimatePresence: React.FC<{ children?: React.ReactNode }> = ({
     children,
 }) => <>{children}</>;

--- a/common/motion.tsx
+++ b/common/motion.tsx
@@ -1,0 +1,18 @@
+import { domAnimation, LazyMotion } from 'framer-motion';
+import React from 'react';
+
+/**
+ * Wraps animated grauity components so framer-motion's lightweight `m`
+ * components load only the DOM animation feature set
+ * (initial / animate / exit / variants / transition) — lazily and
+ * tree-shakeably — instead of eagerly bundling the full `motion` feature set.
+ * grauity uses no drag / layout / pan, so `domAnimation` is the complete set.
+ *
+ * Must wrap ABOVE the `m` components (and any <AnimatePresence>) so the feature
+ * context is available; nesting multiple instances is safe and deduplicated.
+ */
+const GrauityLazyMotion = ({ children }: { children?: React.ReactNode }) => (
+    <LazyMotion features={domAnimation}>{children}</LazyMotion>
+);
+
+export default GrauityLazyMotion;

--- a/ui/elements/Accordion/Accordion.tsx
+++ b/ui/elements/Accordion/Accordion.tsx
@@ -1,6 +1,7 @@
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, m } from 'framer-motion';
 import React, { forwardRef, useEffect, useState } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import { Icon } from '../Icon';
 import {
     StyledAccordionContent,
@@ -52,41 +53,47 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
         };
 
         return (
-            <StyledAccordionWrapper
-                ref={ref}
-                style={style}
-                className={className}
-            >
-                <StyledAccordionHeader
-                    onClick={handleToggle}
-                    $headerBackgroundColor={headerBackgroundColor}
-                    className="ns-accordion-header"
+            <GrauityLazyMotion>
+                <StyledAccordionWrapper
+                    ref={ref}
+                    style={style}
+                    className={className}
                 >
-                    {title}
-                    <StyledAccordionHeaderSuffix>
-                        {suffix}
-                        <Icon
-                            color={iconColor}
-                            name={isExpanded ? 'chevron-up' : 'chevron-down'}
-                            size={iconSize}
-                            className="ns-accordion-icon"
-                        />
-                    </StyledAccordionHeaderSuffix>
-                </StyledAccordionHeader>
-                <AnimatePresence>
-                    {isExpanded && (
-                        <motion.div {...motionProps}>
-                            <StyledAccordionContent
-                                $contentBackgroundColor={contentBackgroundColor}
-                                className="ns-accordion-content"
-                            >
-                                {showSeparator && <StyledLine />}
-                                {children}
-                            </StyledAccordionContent>
-                        </motion.div>
-                    )}
-                </AnimatePresence>
-            </StyledAccordionWrapper>
+                    <StyledAccordionHeader
+                        onClick={handleToggle}
+                        $headerBackgroundColor={headerBackgroundColor}
+                        className="ns-accordion-header"
+                    >
+                        {title}
+                        <StyledAccordionHeaderSuffix>
+                            {suffix}
+                            <Icon
+                                color={iconColor}
+                                name={
+                                    isExpanded ? 'chevron-up' : 'chevron-down'
+                                }
+                                size={iconSize}
+                                className="ns-accordion-icon"
+                            />
+                        </StyledAccordionHeaderSuffix>
+                    </StyledAccordionHeader>
+                    <AnimatePresence>
+                        {isExpanded && (
+                            <m.div {...motionProps}>
+                                <StyledAccordionContent
+                                    $contentBackgroundColor={
+                                        contentBackgroundColor
+                                    }
+                                    className="ns-accordion-content"
+                                >
+                                    {showSeparator && <StyledLine />}
+                                    {children}
+                                </StyledAccordionContent>
+                            </m.div>
+                        )}
+                    </AnimatePresence>
+                </StyledAccordionWrapper>
+            </GrauityLazyMotion>
         );
     }
 );

--- a/ui/elements/BottomSheet/BottomSheet.styles.ts
+++ b/ui/elements/BottomSheet/BottomSheet.styles.ts
@@ -1,11 +1,11 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled, { css } from 'styled-components';
 
 import { StyledDivProps } from '../../../common/types';
 import { DRAG_HANDLE_HEIGHT } from './constants';
 import { StyledBottomSheetContentProps, StyledBottomSheetProps } from './types';
 
-export const StyledBottomSheet = styled(motion.div)<StyledBottomSheetProps>`
+export const StyledBottomSheet = styled(m.div)<StyledBottomSheetProps>`
     width: 100vw;
     height: ${({ $height }) => $height};
     background: var(--bg-subtle-primary-default, #ffffff);

--- a/ui/elements/BottomSheet/BottomSheet.tsx
+++ b/ui/elements/BottomSheet/BottomSheet.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion';
 import React, { forwardRef, useState } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import Overlay from '../Overlay';
 import {
     StyledBottomSheet,
@@ -82,53 +83,57 @@ const BottomSheet = forwardRef<HTMLDivElement, BottomSheetProps>(
         };
 
         return (
-            <AnimatePresence>
-                {isOpen && (
-                    <Overlay
-                        shouldFocusOnFirstElement={shouldFocusOnFirstElement}
-                        shouldDisableScroll={isOpen && shouldDisableScroll}
-                        shouldTintOverlay
-                        onOverlayClick={() => {
-                            if (closeOnBackdropClick) {
-                                handleClose();
+            <GrauityLazyMotion>
+                <AnimatePresence>
+                    {isOpen && (
+                        <Overlay
+                            shouldFocusOnFirstElement={
+                                shouldFocusOnFirstElement
                             }
-                        }}
-                        animationDuration={
-                            ANIMATION_DURATION_IN_MILLISECONDS / 1000
-                        }
-                        data-testid="testid-bottomsheet-wrapper"
-                        className={className}
-                    >
-                        <StyledBottomSheet
-                            ref={ref}
-                            $isOpen={isOpen}
-                            $height={height}
-                            $fullScreen={fullScreen}
-                            $translateY={translateY}
-                            role="dialog"
-                            {...motionProps}
-                        >
-                            {(showDragHandle || closeOnPullDown) && (
-                                <StyledDragHandleContainer
-                                    onTouchStart={handleTouchStart}
-                                    onTouchMove={handleTouchMove}
-                                    onTouchEnd={handleTouchEnd}
-                                >
-                                    <StyledDragHandle />
-                                </StyledDragHandleContainer>
-                            )}
-                            <StyledBottomSheetContent
-                                $height={
-                                    !(showDragHandle || closeOnPullDown) &&
-                                    '100%'
+                            shouldDisableScroll={isOpen && shouldDisableScroll}
+                            shouldTintOverlay
+                            onOverlayClick={() => {
+                                if (closeOnBackdropClick) {
+                                    handleClose();
                                 }
+                            }}
+                            animationDuration={
+                                ANIMATION_DURATION_IN_MILLISECONDS / 1000
+                            }
+                            data-testid="testid-bottomsheet-wrapper"
+                            className={className}
+                        >
+                            <StyledBottomSheet
+                                ref={ref}
+                                $isOpen={isOpen}
+                                $height={height}
+                                $fullScreen={fullScreen}
+                                $translateY={translateY}
+                                role="dialog"
+                                {...motionProps}
                             >
-                                {children}
-                            </StyledBottomSheetContent>
-                        </StyledBottomSheet>
-                    </Overlay>
-                )}
-            </AnimatePresence>
+                                {(showDragHandle || closeOnPullDown) && (
+                                    <StyledDragHandleContainer
+                                        onTouchStart={handleTouchStart}
+                                        onTouchMove={handleTouchMove}
+                                        onTouchEnd={handleTouchEnd}
+                                    >
+                                        <StyledDragHandle />
+                                    </StyledDragHandleContainer>
+                                )}
+                                <StyledBottomSheetContent
+                                    $height={
+                                        !(showDragHandle || closeOnPullDown) &&
+                                        '100%'
+                                    }
+                                >
+                                    {children}
+                                </StyledBottomSheetContent>
+                            </StyledBottomSheet>
+                        </Overlay>
+                    )}
+                </AnimatePresence>
+            </GrauityLazyMotion>
         );
     }
 );

--- a/ui/elements/Drawer/Drawer.styles.ts
+++ b/ui/elements/Drawer/Drawer.styles.ts
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled, { css } from 'styled-components';
 
 import {
@@ -7,7 +7,7 @@ import {
     StyledDrawerProps,
 } from './types';
 
-export const StyledDrawer = styled(motion.div)<StyledDrawerProps>`
+export const StyledDrawer = styled(m.div)<StyledDrawerProps>`
     width: ${({ $width }) => $width};
     height: 100vh;
     background: var(--bg-subtle-primary-default, #ffffff);

--- a/ui/elements/Drawer/Drawer.tsx
+++ b/ui/elements/Drawer/Drawer.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion';
 import React, { forwardRef } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import Overlay from '../Overlay';
 import { ANIMATION_DURATION_IN_MILLISECONDS } from './constants';
 import { StyledDrawer, StyledDrawerContent } from './Drawer.styles';
@@ -38,38 +39,42 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
     };
 
     return (
-        <AnimatePresence>
-            {isOpen && (
-                <Overlay
-                    shouldFocusOnFirstElement={shouldFocusOnFirstElement}
-                    shouldDisableScroll={isOpen && shouldDisableScroll}
-                    shouldTintOverlay
-                    onOverlayClick={() => {
-                        if (closeOnBackdropClick) {
-                            handleClose();
+        <GrauityLazyMotion>
+            <AnimatePresence>
+                {isOpen && (
+                    <Overlay
+                        shouldFocusOnFirstElement={shouldFocusOnFirstElement}
+                        shouldDisableScroll={isOpen && shouldDisableScroll}
+                        shouldTintOverlay
+                        onOverlayClick={() => {
+                            if (closeOnBackdropClick) {
+                                handleClose();
+                            }
+                        }}
+                        animationDuration={
+                            ANIMATION_DURATION_IN_MILLISECONDS / 1000
                         }
-                    }}
-                    animationDuration={
-                        ANIMATION_DURATION_IN_MILLISECONDS / 1000
-                    }
-                    data-testid="testid-drawer-wrapper"
-                    className={className}
-                >
-                    <StyledDrawer
-                        ref={ref}
-                        $isOpen={isOpen}
-                        $width={width}
-                        $fullScreen={fullScreen}
-                        $position={position}
-                        role="dialog"
-                        style={styles}
-                        {...motionProps}
+                        data-testid="testid-drawer-wrapper"
+                        className={className}
                     >
-                        <StyledDrawerContent>{children}</StyledDrawerContent>
-                    </StyledDrawer>
-                </Overlay>
-            )}
-        </AnimatePresence>
+                        <StyledDrawer
+                            ref={ref}
+                            $isOpen={isOpen}
+                            $width={width}
+                            $fullScreen={fullScreen}
+                            $position={position}
+                            role="dialog"
+                            style={styles}
+                            {...motionProps}
+                        >
+                            <StyledDrawerContent>
+                                {children}
+                            </StyledDrawerContent>
+                        </StyledDrawer>
+                    </Overlay>
+                )}
+            </AnimatePresence>
+        </GrauityLazyMotion>
     );
 });
 

--- a/ui/elements/DropdownMenu/DropdownMenu.styles.ts
+++ b/ui/elements/DropdownMenu/DropdownMenu.styles.ts
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled, { css } from 'styled-components';
 
 import {
@@ -10,7 +10,7 @@ import {
     StyledDropdownMenuProps,
 } from './types';
 
-export const StyledDropdownMenu = styled(motion.div)<StyledDropdownMenuProps>`
+export const StyledDropdownMenu = styled(m.div)<StyledDropdownMenuProps>`
     box-sizing: border-box;
     display: flex;
     width: ${({ $width }) => $width};

--- a/ui/elements/DropdownMenu/DropdownMenu.tsx
+++ b/ui/elements/DropdownMenu/DropdownMenu.tsx
@@ -9,6 +9,7 @@ import React, {
     useState,
 } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import { handleKeyboardInteractionInListViews } from '../../../common/utils';
 import { useClickAway } from '../../../hooks';
 import DropdownMenuFooter from './components/DropdownMenuFooter';
@@ -247,159 +248,170 @@ const DropdownMenu = forwardRef<HTMLDivElement, DropdownMenuProps>(
         });
 
         return (
-            <StyledDropdownMenu
-                className={className}
-                style={styles}
-                ref={dropdownRef}
-                $width={width}
-                $maxHeight={maxHeight}
-                role="menu"
-                id={id}
-                {...FRAMER_MOTION_PROPS}
-            >
-                <DropdownMenuHeader
-                    showHeader={showHeader}
-                    overline={overline}
-                    title={title}
-                    subtext={subtext}
-                    customHeader={customHeader}
-                />
-                <StyledDropdownMenuBody>
-                    <DropdownSearchBox
-                        searchRef={searchRef}
-                        searchable={searchable}
-                        searchPlaceholder={searchPlaceholder}
-                        searchIcon={searchIcon}
-                        onSearchInputChange={handleDebouncedSearchInputChange}
-                        onKeyDown={(event) =>
-                            handleKeyDown(
-                                event,
-                                -1,
-                                searchedOptions || options,
-                                searchedOptions ? searchedItemRefs : itemRefs
-                            )
-                        }
+            <GrauityLazyMotion>
+                <StyledDropdownMenu
+                    className={className}
+                    style={styles}
+                    ref={dropdownRef}
+                    $width={width}
+                    $maxHeight={maxHeight}
+                    role="menu"
+                    id={id}
+                    {...FRAMER_MOTION_PROPS}
+                >
+                    <DropdownMenuHeader
+                        showHeader={showHeader}
+                        overline={overline}
+                        title={title}
+                        subtext={subtext}
+                        customHeader={customHeader}
                     />
+                    <StyledDropdownMenuBody>
+                        <DropdownSearchBox
+                            searchRef={searchRef}
+                            searchable={searchable}
+                            searchPlaceholder={searchPlaceholder}
+                            searchIcon={searchIcon}
+                            onSearchInputChange={
+                                handleDebouncedSearchInputChange
+                            }
+                            onKeyDown={(event) =>
+                                handleKeyDown(
+                                    event,
+                                    -1,
+                                    searchedOptions || options,
+                                    searchedOptions
+                                        ? searchedItemRefs
+                                        : itemRefs
+                                )
+                            }
+                        />
 
-                    <StyledDropdownOptionsContainer
-                        onScroll={handleMenuBodyScroll}
-                    >
-                        {Array.isArray(searchedOptions) &&
-                            searchedOptions.map((item, index) => (
-                                <DropdownMenuOption
-                                    key={item.value}
-                                    optionRef={(el) => {
-                                        searchedItemRefs.current[index] = el;
-                                    }}
-                                    multiple={multiple}
-                                    selected={selectedOptions
-                                        .map((option) => option.value)
-                                        .includes(item.value)}
-                                    onClick={(clickedValue) =>
-                                        handleClickOption(
-                                            options.find(
-                                                (option) =>
-                                                    option.value ===
-                                                    clickedValue
+                        <StyledDropdownOptionsContainer
+                            onScroll={handleMenuBodyScroll}
+                        >
+                            {Array.isArray(searchedOptions) &&
+                                searchedOptions.map((item, index) => (
+                                    <DropdownMenuOption
+                                        key={item.value}
+                                        optionRef={(el) => {
+                                            searchedItemRefs.current[index] =
+                                                el;
+                                        }}
+                                        multiple={multiple}
+                                        selected={selectedOptions
+                                            .map((option) => option.value)
+                                            .includes(item.value)}
+                                        onClick={(clickedValue) =>
+                                            handleClickOption(
+                                                options.find(
+                                                    (option) =>
+                                                        option.value ===
+                                                        clickedValue
+                                                )
                                             )
-                                        )
-                                    }
-                                    onKeyDown={(event) =>
-                                        handleKeyDown(
-                                            event,
-                                            index,
-                                            searchedOptions,
-                                            searchedItemRefs
-                                        )
-                                    }
-                                    {...item}
-                                />
-                            ))}
+                                        }
+                                        onKeyDown={(event) =>
+                                            handleKeyDown(
+                                                event,
+                                                index,
+                                                searchedOptions,
+                                                searchedItemRefs
+                                            )
+                                        }
+                                        {...item}
+                                    />
+                                ))}
 
-                        {!Array.isArray(searchedOptions) &&
-                            items.length > 0 &&
-                            items.map((item, index) => {
-                                if (item.type === BaseItemType.SUB_HEADER) {
-                                    return (
-                                        <DropdownMenuSubHeader
-                                            key={`${item.type}-${item.title}`}
-                                            itemRef={(el) => {
-                                                itemRefs.current[index] = el;
-                                            }}
-                                            onKeyDown={(event) =>
-                                                handleKeyDown(
-                                                    event,
-                                                    index,
-                                                    items,
-                                                    itemRefs
-                                                )
-                                            }
-                                            {...item}
-                                        />
-                                    );
-                                }
-                                if (item.type === BaseItemType.DIVIDER) {
-                                    return (
-                                        <StyledDropdownMenuDivider
-                                            key={`${item.type}`}
-                                        />
-                                    );
-                                }
-                                if (item.type === BaseItemType.OPTION) {
-                                    return (
-                                        <DropdownMenuOption
-                                            key={`${item.type}-${item.value}`}
-                                            optionRef={(el) => {
-                                                itemRefs.current[index] = el;
-                                            }}
-                                            multiple={multiple}
-                                            selected={selectedOptions
-                                                .map((option) => option.value)
-                                                .includes(item.value)}
-                                            onClick={(clickedValue) =>
-                                                handleClickOption(
-                                                    options.find(
-                                                        (option) =>
-                                                            option.value ===
-                                                            clickedValue
+                            {!Array.isArray(searchedOptions) &&
+                                items.length > 0 &&
+                                items.map((item, index) => {
+                                    if (item.type === BaseItemType.SUB_HEADER) {
+                                        return (
+                                            <DropdownMenuSubHeader
+                                                key={`${item.type}-${item.title}`}
+                                                itemRef={(el) => {
+                                                    itemRefs.current[index] =
+                                                        el;
+                                                }}
+                                                onKeyDown={(event) =>
+                                                    handleKeyDown(
+                                                        event,
+                                                        index,
+                                                        items,
+                                                        itemRefs
                                                     )
-                                                )
-                                            }
-                                            onKeyDown={(event) =>
-                                                handleKeyDown(
-                                                    event,
-                                                    index,
-                                                    items,
-                                                    itemRefs
-                                                )
-                                            }
-                                            {...item}
-                                        />
-                                    );
-                                }
-                                return null;
-                            })}
+                                                }
+                                                {...item}
+                                            />
+                                        );
+                                    }
+                                    if (item.type === BaseItemType.DIVIDER) {
+                                        return (
+                                            <StyledDropdownMenuDivider
+                                                key={`${item.type}`}
+                                            />
+                                        );
+                                    }
+                                    if (item.type === BaseItemType.OPTION) {
+                                        return (
+                                            <DropdownMenuOption
+                                                key={`${item.type}-${item.value}`}
+                                                optionRef={(el) => {
+                                                    itemRefs.current[index] =
+                                                        el;
+                                                }}
+                                                multiple={multiple}
+                                                selected={selectedOptions
+                                                    .map(
+                                                        (option) => option.value
+                                                    )
+                                                    .includes(item.value)}
+                                                onClick={(clickedValue) =>
+                                                    handleClickOption(
+                                                        options.find(
+                                                            (option) =>
+                                                                option.value ===
+                                                                clickedValue
+                                                        )
+                                                    )
+                                                }
+                                                onKeyDown={(event) =>
+                                                    handleKeyDown(
+                                                        event,
+                                                        index,
+                                                        items,
+                                                        itemRefs
+                                                    )
+                                                }
+                                                {...item}
+                                            />
+                                        );
+                                    }
+                                    return null;
+                                })}
 
-                        {!Array.isArray(searchedOptions) &&
-                            items.length === 0 && (
-                                <StyledDropdownMenuEmptyState>
-                                    <StyledDropdownMenuHeaderSubtext>
-                                        {emptyStateMessage}
-                                    </StyledDropdownMenuHeaderSubtext>
-                                </StyledDropdownMenuEmptyState>
-                            )}
-                    </StyledDropdownOptionsContainer>
-                </StyledDropdownMenuBody>
-                <DropdownMenuFooter
-                    multiple={multiple}
-                    showActionButtons={showActionButtons}
-                    showClearAllButton={showClearAllButton}
-                    clearAllButtonText={clearAllButtonText}
-                    applyButtonText={applyButtonText}
-                    handleClearAll={handleClearAll}
-                    handleApply={handleApply}
-                />
-            </StyledDropdownMenu>
+                            {!Array.isArray(searchedOptions) &&
+                                items.length === 0 && (
+                                    <StyledDropdownMenuEmptyState>
+                                        <StyledDropdownMenuHeaderSubtext>
+                                            {emptyStateMessage}
+                                        </StyledDropdownMenuHeaderSubtext>
+                                    </StyledDropdownMenuEmptyState>
+                                )}
+                        </StyledDropdownOptionsContainer>
+                    </StyledDropdownMenuBody>
+                    <DropdownMenuFooter
+                        multiple={multiple}
+                        showActionButtons={showActionButtons}
+                        showClearAllButton={showClearAllButton}
+                        clearAllButtonText={clearAllButtonText}
+                        applyButtonText={applyButtonText}
+                        handleClearAll={handleClearAll}
+                        handleApply={handleApply}
+                    />
+                </StyledDropdownMenu>
+            </GrauityLazyMotion>
         );
     }
 );

--- a/ui/elements/Modal/Modal.styles.ts
+++ b/ui/elements/Modal/Modal.styles.ts
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
@@ -11,7 +11,7 @@ import {
     ModalTitleProps,
 } from './types';
 
-export const StyledModal = styled(motion.div)<ModalContainerProps>`
+export const StyledModal = styled(m.div)<ModalContainerProps>`
     background: var(--bg-subtle-primary-default, #ffffff);
     z-index: var(--z-index-modal, 1100);
     box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.25);

--- a/ui/elements/Modal/Modal.tsx
+++ b/ui/elements/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import React, {
     useRef,
 } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import { useDisableBodyScroll, useKeyboardEvent } from '../../../hooks';
 import { IconButton } from '../Button';
 import Overlay from '../Overlay';
@@ -103,101 +104,105 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
     );
 
     return (
-        <AnimatePresence>
-            {shouldRender && (
-                <Overlay
-                    shouldDisableScroll={shouldDisableScroll}
-                    onOverlayClick={() => {
-                        if (hideOnClickAway) {
-                            handleClose();
-                        }
-                    }}
-                    shouldTintOverlay
-                    shouldBlurOverlay={blurBackground}
-                    shouldCenterContent
-                    data-testid="testid-modalwrapper"
-                    className={className}
-                    animationDuration={0.3}
-                    shouldFocusOnFirstElement={shouldFocusOnFirstElement}
-                >
-                    <StyledModal
-                        onClick={(e: React.MouseEvent<HTMLDivElement>) =>
-                            e.stopPropagation()
-                        }
-                        ref={modalRef}
-                        width={width}
-                        height={height}
-                        minHeight={minHeight}
-                        minWidth={minWidth}
-                        maxHeight={maxHeight}
-                        maxWidth={maxWidth}
-                        mobileBottomFullWidth={mobileBottomFullWidth}
-                        modalPadding={modalPadding}
-                        $border={border}
-                        aria-labelledby={`modal-title-${id}`}
-                        aria-describedby={`modal-description-${id}`}
-                        aria-modal="true"
-                        role="dialog"
-                        data-testid="testid-modal"
-                        {...motionProps}
+        <GrauityLazyMotion>
+            <AnimatePresence>
+                {shouldRender && (
+                    <Overlay
+                        shouldDisableScroll={shouldDisableScroll}
+                        onOverlayClick={() => {
+                            if (hideOnClickAway) {
+                                handleClose();
+                            }
+                        }}
+                        shouldTintOverlay
+                        shouldBlurOverlay={blurBackground}
+                        shouldCenterContent
+                        data-testid="testid-modalwrapper"
+                        className={className}
+                        animationDuration={0.3}
+                        shouldFocusOnFirstElement={shouldFocusOnFirstElement}
                     >
-                        <StyledModalMain $overflow={overflow}>
-                            {showCloseButton && (
-                                <StyledModalAction justifyContent="end">
-                                    <IconButton
-                                        onClick={handleClose}
-                                        size="small"
-                                        variant="tertiary"
-                                        color="neutral"
-                                        icon="close"
-                                        ariaLabel="Close"
-                                        buttonProps={{ autoFocus: true }}
-                                    />
-                                </StyledModalAction>
-                            )}
+                        <StyledModal
+                            onClick={(e: React.MouseEvent<HTMLDivElement>) =>
+                                e.stopPropagation()
+                            }
+                            ref={modalRef}
+                            width={width}
+                            height={height}
+                            minHeight={minHeight}
+                            minWidth={minWidth}
+                            maxHeight={maxHeight}
+                            maxWidth={maxWidth}
+                            mobileBottomFullWidth={mobileBottomFullWidth}
+                            modalPadding={modalPadding}
+                            $border={border}
+                            aria-labelledby={`modal-title-${id}`}
+                            aria-describedby={`modal-description-${id}`}
+                            aria-modal="true"
+                            role="dialog"
+                            data-testid="testid-modal"
+                            {...motionProps}
+                        >
+                            <StyledModalMain $overflow={overflow}>
+                                {showCloseButton && (
+                                    <StyledModalAction justifyContent="end">
+                                        <IconButton
+                                            onClick={handleClose}
+                                            size="small"
+                                            variant="tertiary"
+                                            color="neutral"
+                                            icon="close"
+                                            ariaLabel="Close"
+                                            buttonProps={{ autoFocus: true }}
+                                        />
+                                    </StyledModalAction>
+                                )}
 
-                            {banner && (
-                                <StyledModalBanner>{banner}</StyledModalBanner>
-                            )}
+                                {banner && (
+                                    <StyledModalBanner>
+                                        {banner}
+                                    </StyledModalBanner>
+                                )}
 
-                            {title && (
-                                <StyledModalTitle id={`modal-title-${id}`}>
-                                    {title}
-                                </StyledModalTitle>
-                            )}
+                                {title && (
+                                    <StyledModalTitle id={`modal-title-${id}`}>
+                                        {title}
+                                    </StyledModalTitle>
+                                )}
 
-                            {description && (
-                                <StyledModalDescription
-                                    id={`modal-description-${id}`}
-                                >
-                                    {description}
-                                </StyledModalDescription>
-                            )}
+                                {description && (
+                                    <StyledModalDescription
+                                        id={`modal-description-${id}`}
+                                    >
+                                        {description}
+                                    </StyledModalDescription>
+                                )}
 
-                            {body && (
-                                <StyledModalBody
-                                    modalBodyMargin={modalBodyMargin}
-                                >
-                                    {body}
-                                </StyledModalBody>
-                            )}
+                                {body && (
+                                    <StyledModalBody
+                                        modalBodyMargin={modalBodyMargin}
+                                    >
+                                        {body}
+                                    </StyledModalBody>
+                                )}
 
-                            {children && (
-                                <StyledModalBody
-                                    modalBodyMargin={modalBodyMargin}
-                                >
-                                    {children}
-                                </StyledModalBody>
-                            )}
-                        </StyledModalMain>
+                                {children && (
+                                    <StyledModalBody
+                                        modalBodyMargin={modalBodyMargin}
+                                    >
+                                        {children}
+                                    </StyledModalBody>
+                                )}
+                            </StyledModalMain>
 
-                        {action && (
-                            <StyledModalAction>{action}</StyledModalAction>
-                        )}
-                    </StyledModal>
-                </Overlay>
-            )}
-        </AnimatePresence>
+                            {action && (
+                                <StyledModalAction>{action}</StyledModalAction>
+                            )}
+                        </StyledModal>
+                    </Overlay>
+                )}
+            </AnimatePresence>
+        </GrauityLazyMotion>
     );
 }) as React.ForwardRefExoticComponent<
     ModalProps & React.RefAttributes<HTMLDivElement>

--- a/ui/elements/Overlay/Overlay.styles.ts
+++ b/ui/elements/Overlay/Overlay.styles.ts
@@ -1,9 +1,9 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled, { css } from 'styled-components';
 
 import { StyledOverlayContentProps, StyledOverlayProps } from './types';
 
-export const StyledOverlay = styled(motion.div)<StyledOverlayProps>`
+export const StyledOverlay = styled(m.div)<StyledOverlayProps>`
     position: fixed;
     top: 0;
     left: 0;

--- a/ui/elements/Overlay/Overlay.tsx
+++ b/ui/elements/Overlay/Overlay.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
+import GrauityLazyMotion from '../../../common/motion';
 import { useDisableBodyScroll } from '../../../hooks';
 import ThemeScope from '../ThemeScope';
 import {
@@ -69,30 +70,32 @@ const Overlay = forwardRef<HTMLDivElement, OverlayProps>((props, ref) => {
     };
 
     return ReactDOM.createPortal(
-        <StyledOverlay
-            ref={ref}
-            onClick={handleOverlayClick}
-            $shouldTintOverlay={shouldTintOverlay}
-            $shouldBlurOverlay={shouldBlurOverlay}
-            $overlayColor={overlayColor}
-            className={className}
-            data-testid="testid-overlay"
-            {...rest}
-            {...motionProps}
-        >
-            <ThemeScope
-                as={StyledOverlayContent}
-                $top={position.top}
-                $left={position.left}
-                $bottom={position.bottom}
-                $shouldCenterContent={shouldCenterContent}
-                style={style}
+        <GrauityLazyMotion>
+            <StyledOverlay
+                ref={ref}
+                onClick={handleOverlayClick}
+                $shouldTintOverlay={shouldTintOverlay}
+                $shouldBlurOverlay={shouldBlurOverlay}
+                $overlayColor={overlayColor}
+                className={className}
+                data-testid="testid-overlay"
+                {...rest}
+                {...motionProps}
             >
-                <StyledOverlayContentChildren ref={childrenRef}>
-                    {children}
-                </StyledOverlayContentChildren>
-            </ThemeScope>
-        </StyledOverlay>,
+                <ThemeScope
+                    as={StyledOverlayContent}
+                    $top={position.top}
+                    $left={position.left}
+                    $bottom={position.bottom}
+                    $shouldCenterContent={shouldCenterContent}
+                    style={style}
+                >
+                    <StyledOverlayContentChildren ref={childrenRef}>
+                        {children}
+                    </StyledOverlayContentChildren>
+                </ThemeScope>
+            </StyledOverlay>
+        </GrauityLazyMotion>,
         document.body
     );
 });

--- a/ui/elements/PopOver/PopOver.styles.ts
+++ b/ui/elements/PopOver/PopOver.styles.ts
@@ -1,10 +1,10 @@
-import { motion } from 'framer-motion';
+import { m } from 'framer-motion';
 import styled, { css } from 'styled-components';
 
 import { StyledPopOverContainerProps } from './types';
 
 export const StyledPopOverContainer = styled(
-    motion.div
+    m.div
 )<StyledPopOverContainerProps>`
     font-family: var(--font-family, 'Mona Sans');
     z-index: var(--z-index-popover, 1200);

--- a/ui/elements/PopOver/PopOver.tsx
+++ b/ui/elements/PopOver/PopOver.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence } from 'framer-motion';
 import React, { useEffect, useRef, useState } from 'react';
 
+import GrauityLazyMotion from '../../../common/motion';
 import Overlay from '../Overlay';
 import { GAP_BETWEEN_TRIGGER_AND_POPOVER } from './constants';
 import { StyledPopOverContainer } from './PopOver.styles';
@@ -266,32 +267,34 @@ export default function PopOver(props: PopOverProps) {
     };
 
     return (
-        <AnimatePresence>
-            {isOpen && (
-                <Overlay
-                    shouldFocusOnFirstElement={shouldFocusOnFirstElement}
-                    shouldDisableScroll={isOpen && disableBackgroundScroll}
-                    onOverlayClick={handleCloseOnOutsideClick}
-                    data-testid="testid-pop-over-wrapper"
-                >
-                    <StyledPopOverContainer
-                        ref={popOverRef}
-                        $offset={adjustedOffset}
-                        {...motionProps}
-                        variants={getMotionVariants(direction)}
-                        className={className}
+        <GrauityLazyMotion>
+            <AnimatePresence>
+                {isOpen && (
+                    <Overlay
+                        shouldFocusOnFirstElement={shouldFocusOnFirstElement}
+                        shouldDisableScroll={isOpen && disableBackgroundScroll}
+                        onOverlayClick={handleCloseOnOutsideClick}
+                        data-testid="testid-pop-over-wrapper"
                     >
-                        <div
-                            style={{
-                                width: width || 'fit-content',
-                                height: height || 'fit-content',
-                            }}
+                        <StyledPopOverContainer
+                            ref={popOverRef}
+                            $offset={adjustedOffset}
+                            {...motionProps}
+                            variants={getMotionVariants(direction)}
+                            className={className}
                         >
-                            {children}
-                        </div>
-                    </StyledPopOverContainer>
-                </Overlay>
-            )}
-        </AnimatePresence>
+                            <div
+                                style={{
+                                    width: width || 'fit-content',
+                                    height: height || 'fit-content',
+                                }}
+                            >
+                                {children}
+                            </div>
+                        </StyledPopOverContainer>
+                    </Overlay>
+                )}
+            </AnimatePresence>
+        </GrauityLazyMotion>
     );
 }


### PR DESCRIPTION
## What

Lazy-load **framer-motion** features in grauity's animated components via `LazyMotion` + the lightweight `m` component, instead of importing the full eager `motion.*` API.

A new shared provider `common/motion.tsx`:

```tsx
import { domAnimation, LazyMotion } from 'framer-motion';

const GrauityLazyMotion = ({ children }) => (
    <LazyMotion features={domAnimation}>{children}</LazyMotion>
);
```

The 7 animated components — **Modal, Drawer, BottomSheet, Overlay, PopOver, Accordion, DropdownMenu** — now:
- wrap their render tree in `<GrauityLazyMotion>`,
- use `styled(m.div)` instead of `styled(motion.div)` (`*.styles.ts`),
- use `m.*` instead of inline `motion.*` (Accordion).

## Why (grauity perf)

`domAnimation` bundles **initial / animate / exit / variants / transition** — every animation these components actually use — while **excluding** the `drag` / `layout` / `pan` / gesture features that eager `motion.*` always pulls in. grauity uses none of those excluded features.

### Measured impact

Bundling each animated component on its own (esbuild, minified, `react`/`react-dom` external), before (`motion`) vs after (`m` + `LazyMotion`):

| Component | gzip before → after | raw before → after |
|---|---|---|
| NSModal | 87.6 → **75.6 KB** (−12.0) | 278.7 → **237.4 KB** (−41.3) |
| NSDrawer | 86.1 → **74.1 KB** (−12.0) | 272.1 → **230.8 KB** (−41.3) |
| NSBottomSheet | 86.4 → **74.3 KB** (−12.1) | 272.9 → **231.6 KB** |
| NSAccordion | 86.2 → **74.2 KB** (−12.0) | 272.6 → **231.3 KB** |
| NSPopOver | 85.8 → **73.7 KB** (−12.1) | 270.7 → **229.4 KB** |
| NSOverlay | 85.8 → **73.7 KB** (−12.1) | 270.7 → **229.4 KB** |
| NSDropdownMenu | 85.8 → **73.7 KB** (−12.1) | 270.7 → **229.4 KB** |

**~12 KB gzip (~41 KB raw, ~14%) off every animated component**, no public API or runtime-behaviour change.

## No public API change

Component props, exports, and animation behaviour are unchanged. This builds on the tree-shakeable tsup build (base branch `build/tsup-tree-shaking`), so consumers that don't import an animated component pay nothing, and those that do now ship less framer-motion.

## Testing — no regression

- `tsc --noEmit`: ✅ clean
- `eslint`: ✅ clean
- `prettier --check`: ✅ clean
- `jest`: ✅ **46 suites / 412 tests pass**
- `tsup build-lib`: ✅ builds, types + dts shim emitted
- **Real-browser** (Vite + Playwright, real framer-motion under `LazyMotion`):
  - Modal **opens** (enter animation, `m.div` + `LazyMotion`) — ✅ PASS
  - Modal **closes**: `#modal-body` present mid-exit, then unmounted — ✅ PASS *(this is the critical check — confirms `AnimatePresence` **exit** animation works under `LazyMotion`/`domAnimation`)*
  - Accordion **expands** (`m.div`) — ✅ PASS
  - **Zero** framer-motion / LazyMotion console errors (a missing-feature misconfiguration would log one)

## Files

- `common/motion.tsx` — new shared `LazyMotion(domAnimation)` provider
- `ui/elements/{Modal,Drawer,BottomSheet,Overlay,PopOver,Accordion,DropdownMenu}/*` — wrap return in `<GrauityLazyMotion>`; `motion.*` → `m.*`
- `__mocks__/framer-motion.tsx` — add `m` / `LazyMotion` / `domAnimation` / `domMax` to the test mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)
