### PR TITLE
perf(deps): drop bundled lodash CJS — lodash-es (tree-shaken) + inline Icon utils (~68KB raw/~13KB gz)

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -18,5 +18,6 @@
     "moduleNameMapper": {
         "^ui/(.*)$": "<rootDir>/ui/$1",
         "framer-motion": "<rootDir>/__mocks__/framer-motion.js"
-    }
+    },
+    "transformIgnorePatterns": ["/node_modules/(?!lodash-es/)"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "@floating-ui/dom": "^1.6.12",
                 "classnames": "^2.3.2",
                 "framer-motion": "^11.11.1",
-                "lodash": "^4.17.21",
                 "yup": "^1.6.1"
             },
             "devDependencies": {
@@ -38,7 +37,7 @@
                 "@testing-library/jest-dom": "^6.5.0",
                 "@testing-library/react": "^16.0.1",
                 "@types/jest": "^29.5.12",
-                "@types/lodash": "^4.17.14",
+                "@types/lodash-es": "^4.17.12",
                 "@types/node": "^18.11.18",
                 "@types/react": "18.2.0",
                 "@types/react-dom": "18.2.0",
@@ -63,6 +62,7 @@
                 "jest": "^29.7.0",
                 "jest-environment-jsdom": "^29.7.0",
                 "lint-staged": "^13.1.0",
+                "lodash-es": "^4.18.1",
                 "mini-css-extract-plugin": "^2.7.2",
                 "path": "^0.12.7",
                 "pre-commit": "^1.2.2",
@@ -4969,6 +4969,16 @@
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
             "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
             "dev": true
+        },
+        "node_modules/@types/lodash-es": {
+            "version": "4.17.12",
+            "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
+            "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/lodash": "*"
+            }
         },
         "node_modules/@types/mdx": {
             "version": "2.0.13",
@@ -12530,13 +12540,15 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash-es": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
-            "dev": true
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@types/jest": "^29.5.12",
-        "@types/lodash": "^4.17.14",
+        "@types/lodash-es": "^4.17.12",
         "@types/node": "^18.11.18",
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.0",
@@ -151,6 +151,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^13.1.0",
+        "lodash-es": "^4.18.1",
         "mini-css-extract-plugin": "^2.7.2",
         "path": "^0.12.7",
         "pre-commit": "^1.2.2",
@@ -176,7 +177,6 @@
         "@floating-ui/dom": "^1.6.12",
         "classnames": "^2.3.2",
         "framer-motion": "^11.11.1",
-        "lodash": "^4.17.21",
         "yup": "^1.6.1"
     },
     "peerDependencies": {

--- a/stories/utils/getKebabCase.tsx
+++ b/stories/utils/getKebabCase.tsx
@@ -1,8 +1,8 @@
-import kebabCase from 'lodash/kebabCase';
+import { kebabCase } from 'lodash-es';
 
 /**
  * Convert a string to kebab case, removing hyphens before numbers
- * 
+ *
  * For example, "MyComponent1" will be converted to "my-component1", instead of "my-component-1"
  * @param str The string to convert to kebab case
  * @returns

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -30,15 +30,16 @@ const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')) as {
 // Externalize all deps + peerDeps (+ their deep-import subpaths) so the consumer
 // dedupes/tree-shakes a single copy and React contexts never break.
 //
-// EXCEPTION: lodash. grauity only deep-imports a few methods (lodash/debounce,
-// lodash/invoke, lodash/isNil). Leaving `lodash/*` external emits extensionless
-// specifiers that Node's native ESM resolver rejects ("Did you mean
-// lodash/debounce.js?"), breaking ESM consumers. Bundling the handful of methods
-// is tiny and fixes ESM. (A lodash-es migration is tracked separately.)
+// lodash-es (the only lodash usage left, `debounce`) is intentionally NOT a
+// dependency/peerDependency — it's a devDependency, so it is NOT in this list
+// and esbuild bundles + tree-shakes it into dist. That keeps the CJS output
+// self-contained (no `require()` of the ESM-only lodash-es) and ships only the
+// handful of bytes `debounce` needs, instead of the ~80KB of non-tree-shakeable
+// lodash CJS the old `lodash/*` deep-imports used to inline.
 const externalPackages = [
     ...Object.keys(pkg.dependencies ?? {}),
     ...Object.keys(pkg.peerDependencies ?? {}),
-].filter((p) => p !== 'lodash');
+];
 const external = [
     ...externalPackages,
     ...externalPackages.map((p) => new RegExp(`^${p}/`)),
@@ -152,10 +153,6 @@ export default defineConfig({
     target: 'es2019',
     platform: 'browser',
     external,
-    // tsup auto-externalizes every package.json dependency. Force-bundle lodash
-    // so its CJS deep-imports (lodash/debounce, ...) are inlined rather than left
-    // as extensionless ESM specifiers Node can't resolve.
-    noExternal: [/^lodash(\/.*)?$/],
     onSuccess: async () => {
         copyStaticAssets();
     },

--- a/ui/elements/DropdownMenu/DropdownMenu.tsx
+++ b/ui/elements/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable indent */
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import React, {
     forwardRef,
     RefObject,

--- a/ui/elements/Form/Combobox/Combobox.tsx
+++ b/ui/elements/Form/Combobox/Combobox.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable indent */
 import { AnimatePresence } from 'framer-motion';
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import DropdownMenu, { BaseItemOptionProps } from '../../DropdownMenu';

--- a/ui/elements/Form/useForm/useForm.tsx
+++ b/ui/elements/Form/useForm/useForm.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import React, { useCallback, useRef, useState } from 'react';
 
 import FormRenderer from './FormRenderer';

--- a/ui/elements/Icon/Icon.tsx
+++ b/ui/elements/Icon/Icon.tsx
@@ -1,6 +1,4 @@
 import classnames from 'classnames';
-import invoke from 'lodash/invoke';
-import isNil from 'lodash/isNil';
 import * as React from 'react';
 
 import { useKeyOnly, useValueAndKey } from '../../helpers';
@@ -36,13 +34,13 @@ function Icon({
             'aria-label'?: string;
         } = {};
 
-        if (isNil(ariaLabel)) {
+        if (ariaLabel == null) {
             ariaOptions['aria-hidden'] = 'true';
         } else {
             ariaOptions['aria-label'] = ariaLabel;
         }
 
-        if (!isNil(ariaHidden)) {
+        if (ariaHidden != null) {
             ariaOptions['aria-hidden'] = ariaHidden;
         }
 
@@ -55,7 +53,10 @@ function Icon({
             return;
         }
 
-        invoke(props, 'onClick', e, props);
+        // Faithful inline of lodash `invoke(props, 'onClick', e, props)`:
+        // call props.onClick (if present) as a method on `props` so `this`
+        // stays bound to props, matching lodash's apply(object, args).
+        (props as { onClick?: (...args: any[]) => void }).onClick?.(e, props);
     };
 
     const ariaOptions = getIconAriaOptions();

--- a/ui/elements/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/ui/elements/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import React, {
     forwardRef,
     useCallback,

--- a/ui/elements/SelectDropdown/SelectDropdown.tsx
+++ b/ui/elements/SelectDropdown/SelectDropdown.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import { debounce } from 'lodash-es';
 import React, { forwardRef, useCallback, useRef, useState } from 'react';
 
 import Button from '../Button';


### PR DESCRIPTION
## What

Removes the **force-bundled lodash CJS** from grauity's published output by migrating to **lodash-es** (tree-shaken) and inlining two trivial helpers. No public API or runtime-behaviour change.

## Why (grauity perf)

The tsup build currently force-bundles lodash (`tsup.config.ts`: `.filter(p => p !== 'lodash')` + `noExternal: [/^lodash/]`) because Node's ESM resolver rejects extensionless `'lodash/x'` deep specifiers. lodash was used for only **3 functions / 7 sites**: `debounce` (×5), `invoke` (×1), `isNil` (×1) — yet the workaround inlined **~84 KB raw / ~17 KB gzip** of non-tree-shakeable lodash CJS across the ESM + CJS chunks.

### Measured impact

| | raw | gzip |
|---|---|---|
| lodash footprint **before** (4 chunks) | 83,738 B | 17,237 B |
| lodash footprint **after** (debounce only, tree-shaken) | 14,861 B | 4,443 B |
| **removed** | **−68,877 B** | **−12,794 B** |

Total `dist` (ESM+CJS): **1,013,949 → 946,227 B** (−67,722 B). The heavy `invoke` path-resolution machinery (`baseInvoke`/`castPath`/`stringToPath`, the ~35 KB chunk) is **gone entirely**; `debounce` is tree-shaken to ~7.4 KB.

## How

- **`Icon.tsx`** — inline the two trivial lodash utils (behaviour-preserving):
  - `isNil(x)` → `x == null` (lodash `isNil` *is* `value == null`)
  - `invoke(props, 'onClick', e, props)` → `props.onClick?.(e, props)` — a method call on `props`, so `this === props`, exactly matching lodash `invoke`'s `apply(object, args)`; `?.` matches its nil-guard; `'onClick'` is a simple key so no deep-path semantics are lost.
- **5 `debounce` sites** (`useForm`, `Combobox`, `DropdownMenu`, `SelectDropdown`, `MultiSelectDropdown`) → `import { debounce } from 'lodash-es'`. All are the plain `debounce(fn, ms)` form (no `.cancel()`/`.flush()`/options/return-value), so lodash-es debounce is a drop-in.
- **`stories/utils/getKebabCase.tsx`** (dev-only) → lodash-es `kebabCase`, so `lodash` can be removed entirely.
- **`lodash-es` is a bundled devDependency, not externalized**: esbuild inlines + tree-shakes it, so the **CJS output stays self-contained** (no `require()` of the ESM-only lodash-es → no consumer interop/resolution risk) and consumers need no new dependency.
- **`tsup.config.ts`** — drop the lodash special-casing (unneeded now).
- **`jest.config.json`** — `transformIgnorePatterns: ["/node_modules/(?!lodash-es/)"]` so ts-jest can transform lodash-es's ESM (test-only; doesn't affect the published build).
- **deps** — remove `lodash` + `@types/lodash`; add `lodash-es` + `@types/lodash-es` (devDeps).

## Testing — no regression

- `tsc --noEmit` ✅ · `eslint` ✅ · `prettier --check` ✅
- `jest` ✅ **46 suites / 412 tests pass** (incl. all 5 debounce components + Icon)
- `tsup build-lib` ✅ — dist inspection confirms **no externalized lodash-es** (`require("lodash-es")`/`from "lodash-es"` absent → inlined) and **no invoke machinery**
- **Consumer smoke tests**: CJS `require` of the built barrel loads all affected components ✅; a **bundler consumer** (esbuild, react/styled-components external — i.e. Next/webpack/vite) bundles OK with debounce inlined ✅
- Pre-existing styled-components v6 raw-Node-ESM interop (`styled.x` undefined) is **unrelated** — a component G6 never touched (`Button`) fails identically; bundler consumers are unaffected
- Independently **adversarially reviewed** (lodash `invoke`/`isNil`/`debounce` semantics checked against source; verdict: GO)

## Note

This builds on the tsup tree-shaking foundation (base branch `build/tsup-tree-shaking`). The companion G6 item (`babel-plugin-styled-components`) was investigated and **dropped**: `.babelrc` only feeds Storybook (jest/Storybook override it), the published build is Babel-free (esbuild), so it can't reach `dist` and yields ~0 perf for real regression risk — SSR class-name stability, if ever needed, belongs in the consumer's build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
