### PR TITLE
fix(tabs): make NSTabs keyboard operable (WCAG 2.1.1)

### DIFF
--- a/stories/elements/Tabs/index.stories.tsx
+++ b/stories/elements/Tabs/index.stories.tsx
@@ -29,3 +29,13 @@ export const Component = Template.bind({});
 Component.args = {
     ...defaultArgs,
 };
+
+// Keyboard-navigable: Tab into the strip, then Arrow Left/Right/Home/End to
+// move focus and Enter/Space to select. `ariaLabel` names the tablist for
+// assistive tech. Use the Accessibility (a11y) panel to verify.
+export const KeyboardNavigation = Template.bind({});
+
+KeyboardNavigation.args = {
+    tabItems: ['Overview', 'Activity', 'Settings', 'Members'],
+    ariaLabel: 'Project sections',
+};

--- a/ui/elements/Tabs/Tabs.styles.ts
+++ b/ui/elements/Tabs/Tabs.styles.ts
@@ -58,6 +58,10 @@ export const StyledTabItemContainer = styled.div<StyledTabItemContainerProps>`
             color: ${$focusColor ||
             'var(--text-emphasis-brand-default, #0673f9)'};
         `}
+
+    &:focus-visible {
+        outline: 3px solid var(--border-subtle-brand-default, #61a8ff);
+    }
 `;
 
 export const StyledTabItemText = styled.span<StyledTextProps>`

--- a/ui/elements/Tabs/Tabs.test.tsx
+++ b/ui/elements/Tabs/Tabs.test.tsx
@@ -11,6 +11,8 @@ const defaultProps: TabsProps = {
     onTabFocusChange: jest.fn(),
 };
 
+const threeTabs = ['One', 'Two', 'Three'];
+
 describe('Tabs Component', () => {
     it('renders without crashing', () => {
         render(<Tabs tabItems={['Item1', 'Item2']} />);
@@ -36,5 +38,179 @@ describe('Tabs Component', () => {
         render(<Tabs tabItems={['Item1', 'Item2']} className="custom-class" />);
         const tablist = screen.getByRole('tablist');
         expect(tablist).toHaveClass('custom-class');
+    });
+});
+
+describe('Tabs Component - accessibility', () => {
+    it('renders each item as a tab with a roving tabIndex', () => {
+        render(<Tabs tabItems={['Item1', 'Item2']} />);
+
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs).toHaveLength(2);
+        expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[0]).toHaveAttribute('tabIndex', '0');
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+        expect(tabs[1]).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('honours initialActiveTab for selection and the tab stop', () => {
+        render(<Tabs tabItems={threeTabs} initialActiveTab={1} />);
+
+        const tabs = screen.getAllByRole('tab');
+        expect(tabs[0]).toHaveAttribute('tabIndex', '-1');
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[1]).toHaveAttribute('tabIndex', '0');
+        expect(tabs[2]).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('keeps a tab reachable when initialActiveTab is out of range', () => {
+        render(<Tabs tabItems={threeTabs} initialActiveTab={-1} />);
+
+        const tabs = screen.getAllByRole('tab');
+        // No tab is selected, but the first stays keyboard-tabbable (no trap).
+        expect(tabs[0]).toHaveAttribute('tabIndex', '0');
+        expect(tabs[1]).toHaveAttribute('tabIndex', '-1');
+        expect(tabs[2]).toHaveAttribute('tabIndex', '-1');
+
+        const tablist = screen.getByRole('tablist');
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+        expect(tabs[1]).toHaveFocus();
+    });
+
+    it('labels the tablist (default) and accepts a custom ariaLabel', () => {
+        const { rerender } = render(<Tabs tabItems={['Item1', 'Item2']} />);
+        expect(screen.getByRole('tablist')).toHaveAttribute(
+            'aria-label',
+            'Tab list'
+        );
+
+        rerender(<Tabs tabItems={['Item1', 'Item2']} ariaLabel="Views" />);
+        expect(screen.getByRole('tablist')).toHaveAttribute(
+            'aria-label',
+            'Views'
+        );
+    });
+});
+
+describe('Tabs Component - keyboard navigation', () => {
+    it('ArrowRight moves focus to the next tab', () => {
+        render(<Tabs tabItems={threeTabs} />);
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+
+        expect(tabs[1]).toHaveFocus();
+    });
+
+    it('ArrowLeft moves focus to the previous tab', () => {
+        render(<Tabs tabItems={threeTabs} initialActiveTab={1} />);
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[1].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
+
+        expect(tabs[0]).toHaveFocus();
+    });
+
+    it('ArrowRight wraps from the last tab to the first', () => {
+        render(<Tabs tabItems={threeTabs} initialActiveTab={2} />);
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[2].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+
+        expect(tabs[0]).toHaveFocus();
+    });
+
+    it('ArrowLeft wraps from the first tab to the last', () => {
+        render(<Tabs tabItems={threeTabs} />);
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowLeft' });
+
+        expect(tabs[2]).toHaveFocus();
+    });
+
+    it('Home focuses the first tab and End the last', () => {
+        render(<Tabs tabItems={threeTabs} initialActiveTab={1} />);
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[1].focus();
+        fireEvent.keyDown(tablist, { key: 'End' });
+        expect(tabs[2]).toHaveFocus();
+
+        fireEvent.keyDown(tablist, { key: 'Home' });
+        expect(tabs[0]).toHaveFocus();
+    });
+
+    it('does not change selection while only moving focus (manual activation)', () => {
+        const onTabFocusChange = jest.fn();
+        render(
+            <Tabs tabItems={threeTabs} onTabFocusChange={onTabFocusChange} />
+        );
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        // Mount fires once with the initial index (0).
+        expect(onTabFocusChange).toHaveBeenCalledTimes(1);
+        expect(onTabFocusChange).toHaveBeenLastCalledWith(0);
+
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+
+        // Focus moved but selection did not commit.
+        expect(tabs[1]).toHaveFocus();
+        expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+        expect(onTabFocusChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('Enter commits the focused tab', () => {
+        const onTabFocusChange = jest.fn();
+        render(
+            <Tabs tabItems={threeTabs} onTabFocusChange={onTabFocusChange} />
+        );
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+        fireEvent.keyDown(tablist, { key: 'Enter' });
+
+        expect(onTabFocusChange).toHaveBeenLastCalledWith(1);
+        expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+        expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('Space commits the focused tab', () => {
+        const onTabFocusChange = jest.fn();
+        render(
+            <Tabs tabItems={threeTabs} onTabFocusChange={onTabFocusChange} />
+        );
+
+        const tablist = screen.getByRole('tablist');
+        const tabs = screen.getAllByRole('tab');
+
+        tabs[0].focus();
+        fireEvent.keyDown(tablist, { key: 'End' });
+        fireEvent.keyDown(tablist, { key: ' ' });
+
+        expect(onTabFocusChange).toHaveBeenLastCalledWith(2);
+        expect(tabs[2]).toHaveAttribute('aria-selected', 'true');
     });
 });

--- a/ui/elements/Tabs/Tabs.tsx
+++ b/ui/elements/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { KeyboardEvent, useEffect, useRef, useState } from 'react';
 
 import {
     StyledTabContainer,
@@ -17,23 +17,88 @@ function Tabs(props: TabsProps) {
         focusColor = null,
         color = null,
         className = '',
+        ariaLabel = 'Tab list',
     } = props;
 
     const [activeTab, setActiveTab] = useState(initialActiveTab);
+    // The roving tab stop: exactly one tab is keyboard-tabbable at a time.
+    // Seeded to the selected tab and re-synced to it on every commit, so
+    // arrow keys move a focus ring while selection stays put until Enter /
+    // Space / click (manual activation, mirroring NSTabList).
+    const [focusedIndex, setFocusedIndex] = useState(initialActiveTab);
+    const containerRef = useRef<HTMLDivElement>(null);
 
     const handleItemClick = (activeTabIndex: number) => {
         setActiveTab(activeTabIndex);
     };
 
+    // Fires on mount (with the initial tab) and on every selection change —
+    // left exactly as before so consumers see identical callback timing.
     useEffect(() => {
         onTabFocusChange(activeTab);
     }, [activeTab]);
 
+    // Realign the roving focus to the selected tab after any commit.
+    useEffect(() => {
+        setFocusedIndex(activeTab);
+    }, [activeTab]);
+
+    const focusTab = (index: number) => {
+        const container = containerRef.current;
+        if (container) {
+            const tab = container.querySelectorAll('[role="tab"]')[
+                index
+            ] as HTMLElement;
+            if (tab) {
+                tab.focus();
+            }
+        }
+    };
+
+    // The tab that currently holds the roving stop. Clamped so an out-of-range
+    // `focusedIndex` (e.g. an out-of-range `initialActiveTab`) can never leave
+    // every tab untabbable — at least the first tab stays keyboard-reachable.
+    const count = tabItems.length;
+    const rovingIndex =
+        focusedIndex >= 0 && focusedIndex < count ? focusedIndex : 0;
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+        if (count === 0) {
+            return;
+        }
+        let nextIndex: number | null = null;
+
+        if (e.key === 'ArrowRight') {
+            nextIndex = (rovingIndex + 1) % count;
+        } else if (e.key === 'ArrowLeft') {
+            nextIndex = (rovingIndex - 1 + count) % count;
+        } else if (e.key === 'Home') {
+            nextIndex = 0;
+        } else if (e.key === 'End') {
+            nextIndex = count - 1;
+        } else if (e.key === ' ' || e.key === 'Enter') {
+            // Manual activation: commit the focused tab. Reuses the click
+            // handler so selection + onTabFocusChange fire identically.
+            e.preventDefault();
+            handleItemClick(rovingIndex);
+            return;
+        } else {
+            return;
+        }
+
+        e.preventDefault();
+        setFocusedIndex(nextIndex);
+        focusTab(nextIndex);
+    };
+
     return (
         <StyledTabContainer
+            ref={containerRef}
             $backgroundColor={backgroundColor}
             className={className}
             role="tablist"
+            aria-label={ariaLabel}
+            onKeyDown={handleKeyDown}
         >
             {tabItems?.map((item, idx) => (
                 <StyledTabItemContainer
@@ -43,6 +108,9 @@ function Tabs(props: TabsProps) {
                     $focusBackgroundColor={focusBackgroundColor}
                     $focusColor={focusColor}
                     key={typeof item === 'string' ? item : String(item) + idx}
+                    role="tab"
+                    aria-selected={activeTab === idx}
+                    tabIndex={rovingIndex === idx ? 0 : -1}
                 >
                     {typeof item === 'string' ? (
                         <StyledTabItemText>{item}</StyledTabItemText>

--- a/ui/elements/Tabs/types.ts
+++ b/ui/elements/Tabs/types.ts
@@ -64,4 +64,10 @@ export interface TabsProps {
      * @default ''
      */
     className?: string;
+
+    /**
+     * Accessible name for the tablist, applied as `aria-label`.
+     * @default 'Tab list'
+     */
+    ariaLabel?: string;
 }


### PR DESCRIPTION
## Description

`NSTabs` (`ui/elements/Tabs`) was **not keyboard operable** — a WCAG 2.1.1 (Keyboard) failure. The container carried `role="tablist"`, but each tab item was a click-only `div` with no `role="tab"`, `tabIndex`, `aria-selected`, or keyboard handler, so keyboard-only and screen-reader users could neither reach nor operate the tabs. Every consumer is affected (the Calendar view switcher; the KoyoGP time picker; downstream apps such as newton-web's TMS resources File/Link switch).

This transplants the accessible pattern grauity already ships in the sibling `NSTabList`/`NSTab` into `NSTabs`, with **no change to the public contract or existing runtime behavior**.

### What changed
- Each tab now renders `role="tab"`, `aria-selected`, and a **roving `tabIndex`** (exactly one tab is tabbable; on mount it's the selected tab — clamped so an out-of-range `initialActiveTab` can never leave every tab untabbable).
- Container-level keyboard handling: **Arrow Left/Right** (with wraparound), **Home/End**, and **Enter/Space** to select. **Manual activation** — arrows move focus, Enter/Space/click commit.
- New **`:focus-visible`** ring reusing the same token as `NSTab`/`NSTabList` (`--border-subtle-brand-default`).
- New **optional** `ariaLabel` prop (default `'Tab list'`) to give the tablist an accessible name.
- Unit tests for roles / aria-selected / roving tabindex / keyboard nav, plus a `KeyboardNavigation` story so the Storybook a11y panel demonstrates the fix.

### Zero-regression
- `TabsProps` gains **only** an optional `ariaLabel` — nothing removed, renamed, or retyped.
- `onTabFocusChange` fires **exactly** as before: once on mount (initial index) and on every commit (click / Enter / Space). Arrows do **not** fire it (manual activation), so consumers like the Calendar view switcher see identical callback timing.
- Uncontrolled `activeTab` + `initialActiveTab` seeding, string/`ReactNode` item rendering, `role="tablist"` + `className` passthrough, and the click path are unchanged. The item stays a `<div>` (no UA button reset, no nested-interactive risk with arbitrary node items).

### Out of scope (intentional)
Tab↔tabpanel `aria-controls`/`id` wiring — `NSTabs` renders no panels; that would need consumer-supplied ids (a future additive prop), not a regression fix.

### Verification
- `npm run typecheck` clean · `npm run lint` clean · `npm run test` green (46 suites / 423 tests, including the Calendar suite).
- Manual: Tab into the strip; Arrow/Home/End move focus; Enter/Space/click select; focus ring visible; Storybook a11y panel reports no violations (Elements/Tabs → **KeyboardNavigation**).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Related Issues

Motivated by an accessibility finding during review of a downstream consumer (newton-web PR #8745). No grauity issue filed yet.

## Checklist

- [x] PR name uses present imperative tense and specifically describes the changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (JSDoc on the new prop + a story)
- [x] My changes generate no new TypeScript warnings
- [x] My changes does not hide eslint warnings un-necessarily
- [x] My pull request maintains linear history with the master branch

## Additional Notes

Behavior model chosen is **manual activation** (mirrors `NSTabList`) specifically to preserve `onTabFocusChange`'s current firing timing for existing consumers. Automatic activation (selection-follows-focus) was considered and rejected because it would fire the callback on every arrow keypress, changing callback frequency for the Calendar view switcher.
