### PR TITLE
Bump version to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@newtonschool/grauity",
-            "version": "3.5.0",
+            "version": "3.5.1",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "Design System for Newton School",
     "keywords": [
         "Newton School",


### PR DESCRIPTION
## Summary

Patch version bump: `3.5.0` → `3.5.1`.

- `package.json` and `package-lock.json` updated via `npm version patch --no-git-tag-version`
- `npm install` run afterwards to confirm the lockfile is in sync (reported `up to date`, no dependency changes)

No source or dependency changes — version fields only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)