### PR TITLE
Bump version to 3.5.3 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@newtonschool/grauity",
-            "version": "3.5.2",
+            "version": "3.5.3",
             "license": "MIT",
             "dependencies": {
                 "@floating-ui/dom": "^1.6.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@newtonschool/grauity",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "description": "Design System for Newton School",
     "keywords": [
         "Newton School",


### PR DESCRIPTION
## Why

The 8 Media/System icon pairs from #343 are on `master` but **not published**. The `v3.5.2` tag sits at `1c8e770` (the previous version bump) and `bda739e` (the icons) landed after it, so npm `latest` @ 3.5.2 is missing them.

```
1c8e770  Bump version to 3.5.2                  ← v3.5.2 tag, npm latest
bda739e  Add 8 Media/System icon pairs (#343)    ← unreleased
```

## What ships in 3.5.3

Diffing `v3.5.2` against `master` — 8 new pairs, no removals (926 → 958 exported names):

| Icon | Variants |
| --- | --- |
| `ai-summary` | + `-filled` |
| `dot-circle` | + `-filled` |
| `question` | + `-filled` |
| `screen-share` | + `-filled` |
| `skip-next` | + `-filled` |
| `skip-previous` | + `-filled` |
| `split-screen` | + `-filled` |
| `transcript` | + `-filled` |

## Changes

- Version `3.5.2` → `3.5.3` in `package.json` + `package-lock.json`.
- `iconland` submodule pointer `0cc5dd2` → `a702258`.

On the submodule: `0cc5dd2` was the pre-squash commit from the iconland PR branch and is not reachable from iconland's `master` (upstream squash-merged it as `a702258`). Both trees are byte-identical, so the built icon set is unchanged. This matters because `npm run build` regenerates `ui/core/icons/*.ts` from `iconland/seeds` at publish time — the submodule pointer, not the committed files, determines the published icon set.

## Verification

- `npm run build` passes; all 8 pairs present in `dist/ui/core/icons/iconTypes.d.ts` and the regenerated `grauity-icons.woff2`. 479 seeds → 479 optimised.
- Regenerating icons on `master` produces no semantic diff — confirms the committed icon files were already in sync.

## After merge

Create a GitHub release tagged **`v3.5.3`** to trigger `publish-npm-package.yml`.

⚠️ Tag the merge commit of this PR, not an earlier one — cutting the tag before the content lands is exactly what made 3.5.2 miss these icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)