### PR TITLE
Fit dropdown menus to the viewport, in both menus and on both axes

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useClickAway } from './useClickAway';
 export { default as useDisableBodyScroll } from './useDisableBodyScroll';
+export { default as useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 export { default as useKeyboardEvent } from './useKeyboardEvent';

--- a/hooks/useIsomorphicLayoutEffect.ts
+++ b/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,14 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` on the client, `useEffect` on the server.
+ *
+ * Layout effects are the right tool for measuring a node and repositioning it
+ * before the browser paints, but React warns when one is called during server
+ * rendering. Consumers such as Next.js render grauity on the server, so the
+ * effect is swapped for `useEffect` there, where it is a no-op anyway.
+ */
+const useIsomorphicLayoutEffect =
+    typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/ui/elements/DropdownMenu/constants.ts
+++ b/ui/elements/DropdownMenu/constants.ts
@@ -1,5 +1,9 @@
 export const ANIMATION_DURATION_IN_MILLISECONDS = 200;
 export const DROPDOWN_MENU_MAX_HEIGHT = 500;
+export const DROPDOWN_MENU_DEFAULT_WIDTH = 300;
+
+/** Smallest gap kept between the dropdown menu and the edge of the viewport. */
+export const DROPDOWN_MENU_VIEWPORT_GAP = 20;
 
 export const FRAMER_MOTION_PROPS = {
     initial: 'hidden',

--- a/ui/elements/DropdownMenu/constants.ts
+++ b/ui/elements/DropdownMenu/constants.ts
@@ -5,14 +5,21 @@ export const DROPDOWN_MENU_DEFAULT_WIDTH = 300;
 /** Smallest gap kept between the dropdown menu and the edge of the viewport. */
 export const DROPDOWN_MENU_VIEWPORT_GAP = 20;
 
+/**
+ * Vertical offset the menu settles at, away from its trigger. It is applied as a
+ * transform by the entry animation below, so it does not show up in the menu's
+ * own box and has to be added back when fitting the menu to the viewport.
+ */
+export const DROPDOWN_MENU_OFFSET_Y = 8;
+
 export const FRAMER_MOTION_PROPS = {
     initial: 'hidden',
     animate: 'visible',
     exit: 'exit',
     variants: {
-        hidden: { y: '-8px', opacity: 0 },
-        visible: { y: '8px', opacity: 1 },
-        exit: { y: '-8px', opacity: 0 },
+        hidden: { y: `-${DROPDOWN_MENU_OFFSET_Y}px`, opacity: 0 },
+        visible: { y: `${DROPDOWN_MENU_OFFSET_Y}px`, opacity: 1 },
+        exit: { y: `-${DROPDOWN_MENU_OFFSET_Y}px`, opacity: 0 },
     },
     transition: { duration: ANIMATION_DURATION_IN_MILLISECONDS / 1000 },
 };

--- a/ui/elements/DropdownMenu/utils.ts
+++ b/ui/elements/DropdownMenu/utils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { DROPDOWN_MENU_VIEWPORT_GAP } from './constants';
 import { BaseItemOptionProps, BaseItemProps, BaseItemType } from './types';
 
 /**
@@ -89,4 +90,29 @@ export function scrollToFirstMarkedItem(
             }
         }, delay);
     }
+}
+
+/**
+ * Keeps one axis of a dropdown menu inside the viewport.
+ *
+ * A menu that already fits is left exactly where its trigger puts it — the
+ * clamp engages only on a real overflow, matching how PopOver adjusts, so
+ * ordinary placements are never nudged out of alignment with their trigger.
+ * When it does engage the menu is pulled back to leave a gap, or flush to the
+ * near edge when the menu is larger than the viewport and no gap will fit.
+ *
+ * @param anchor - The preferred position, taken from the trigger.
+ * @param menuSize - The menu's size along this axis, including any offset it settles at.
+ * @param viewportSize - The viewport's size along this axis.
+ */
+export function clampMenuAxisToViewport(
+    anchor: number,
+    menuSize: number,
+    viewportSize: number
+) {
+    if (anchor + menuSize <= viewportSize) {
+        return Math.max(0, anchor);
+    }
+
+    return Math.max(0, viewportSize - menuSize - DROPDOWN_MENU_VIEWPORT_GAP);
 }

--- a/ui/elements/Form/Combobox/Combobox.tsx
+++ b/ui/elements/Form/Combobox/Combobox.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence } from 'framer-motion';
 import { debounce } from 'lodash-es';
 import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
 
+import { useIsomorphicLayoutEffect } from '../../../../hooks';
 import DropdownMenu, { BaseItemOptionProps } from '../../DropdownMenu';
 import { DROPDOWN_MENU_MAX_HEIGHT } from '../../DropdownMenu/constants';
 import {
@@ -138,9 +139,15 @@ const Combobox = (props: ComboboxProps) => {
         setSearchedOptions(null);
     }, [items]);
 
-    useEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         const { position, maxHeight, style } =
-            calculateDropdownMenuLayoutForCombobox(triggerRef);
+            calculateDropdownMenuLayoutForCombobox(
+                triggerRef,
+                DROPDOWN_MENU_MAX_HEIGHT,
+                // Null until the menu is on screen, in which case there is
+                // nothing to fit to the viewport yet.
+                dropdownMenuRef.current?.offsetWidth ?? 0
+            );
         setDropdownMenuHeight(maxHeight);
         setDropdownMenuPosition(position);
         setOverlayStyles(style);

--- a/ui/elements/Form/Combobox/utils.test.ts
+++ b/ui/elements/Form/Combobox/utils.test.ts
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { calculateDropdownMenuLayoutForCombobox } from './utils';
+
+const VIEWPORT_WIDTH = 1280;
+const VIEWPORT_HEIGHT = 720;
+
+const triggerAt = (rect: Partial<DOMRect>) =>
+    ({
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0,
+                width: 0,
+                height: 0,
+                ...rect,
+            }),
+        },
+    } as React.RefObject<HTMLDivElement>);
+
+describe('calculateDropdownMenuLayoutForCombobox', () => {
+    beforeEach(() => {
+        window.innerWidth = VIEWPORT_WIDTH;
+        window.innerHeight = VIEWPORT_HEIGHT;
+    });
+
+    it('anchors to the trigger when the menu fits on screen', () => {
+        const { position } = calculateDropdownMenuLayoutForCombobox(
+            triggerAt({ left: 100, top: 40, bottom: 80 }),
+            500,
+            280
+        );
+
+        expect(position.left).toBe(100);
+    });
+
+    it('pulls the menu back in when the trigger sits near the right edge', () => {
+        const { position } = calculateDropdownMenuLayoutForCombobox(
+            triggerAt({ left: 1155, top: 40, bottom: 80 }),
+            500,
+            280
+        );
+
+        expect(position.left).toBe(VIEWPORT_WIDTH - 280 - 20);
+        expect(position.left + 280).toBeLessThanOrEqual(VIEWPORT_WIDTH);
+    });
+
+    // The menu flips above the trigger when there is more room there; that
+    // branch anchors horizontally the same way and must be fitted too.
+    it('fits the menu to the viewport when it opens upwards', () => {
+        const { position } = calculateDropdownMenuLayoutForCombobox(
+            triggerAt({ left: 1155, top: 600, bottom: 640 }),
+            500,
+            280
+        );
+
+        expect(position.bottom).toBeDefined();
+        expect(position.left).toBe(VIEWPORT_WIDTH - 280 - 20);
+    });
+
+    // Callers that do not pass a width keep their previous placement.
+    it('leaves the anchor untouched when no menu width is known', () => {
+        const { position } = calculateDropdownMenuLayoutForCombobox(
+            triggerAt({ left: 1155, top: 40, bottom: 80 })
+        );
+
+        expect(position.left).toBe(1155);
+    });
+});

--- a/ui/elements/Form/Combobox/utils.ts
+++ b/ui/elements/Form/Combobox/utils.ts
@@ -1,18 +1,25 @@
 import React from 'react';
 
 import { DROPDOWN_MENU_MAX_HEIGHT } from '../../DropdownMenu/constants';
+import { clampMenuAxisToViewport } from '../../DropdownMenu/utils';
 
 /**
  * Calculates the layout: position, height and other styles for a Combobox menu (DropdownMenu)
  * based on the position of the trigger element, and the space available in the viewport.
  *
+ * The menu is fitted to the viewport horizontally, so a trigger near the right
+ * edge cannot push it off screen where the overlay's disabled scroll would leave
+ * it unreachable. A menu that already fits is not moved.
+ *
  * @param triggerRef - A ref to the HTMLDivElement or HTMLButtonElement that triggers the dropdown menu.
  * @param maximumMenuHeight - The maximum height of the dropdown menu, defaults to '500px'.
+ * @param menuWidth - The width of the dropdown menu, used to fit it to the viewport.
  * @returns An object containing the position object, height and styles for the dropdown menu.
  */
 export function calculateDropdownMenuLayoutForCombobox(
     triggerRef: React.RefObject<HTMLButtonElement | HTMLDivElement>,
-    maximumMenuHeight: number = DROPDOWN_MENU_MAX_HEIGHT
+    maximumMenuHeight: number = DROPDOWN_MENU_MAX_HEIGHT,
+    menuWidth: number = 0
 ) {
     const triggerRect = triggerRef.current?.getBoundingClientRect();
     const windowHeight = window.innerHeight;
@@ -27,12 +34,17 @@ export function calculateDropdownMenuLayoutForCombobox(
 
     const spaceBelow = windowHeight - triggerRect.bottom;
     const spaceAbove = triggerRect.top;
+    const left = clampMenuAxisToViewport(
+        triggerRect.left,
+        menuWidth,
+        window.innerWidth
+    );
 
     if (spaceAbove > spaceBelow) {
         return {
             position: {
                 bottom: windowHeight - triggerRect.top + 20,
-                left: triggerRect.left,
+                left,
             },
             maxHeight: Math.min(spaceAbove - 20, maximumMenuHeight),
             style: {
@@ -45,7 +57,7 @@ export function calculateDropdownMenuLayoutForCombobox(
     return {
         position: {
             top: triggerRect.bottom,
-            left: triggerRect.left,
+            left,
         },
         maxHeight: Math.min(spaceBelow - 20, maximumMenuHeight),
         style: {},

--- a/ui/elements/Form/Dropdown/Dropdown.tsx
+++ b/ui/elements/Form/Dropdown/Dropdown.tsx
@@ -2,8 +2,12 @@
 import { AnimatePresence } from 'framer-motion';
 import React, { useEffect, useRef, useState } from 'react';
 
+import { useIsomorphicLayoutEffect } from '../../../../hooks';
 import DropdownMenu, { BaseItemOptionProps } from '../../DropdownMenu';
-import { DROPDOWN_MENU_MAX_HEIGHT } from '../../DropdownMenu/constants';
+import {
+    DROPDOWN_MENU_DEFAULT_WIDTH,
+    DROPDOWN_MENU_MAX_HEIGHT,
+} from '../../DropdownMenu/constants';
 import { getSelectedValuesForDropdownType } from '../../DropdownMenu/utils';
 import Overlay from '../../Overlay';
 import DropdownTrigger from './DropdownTrigger';
@@ -27,14 +31,15 @@ const Dropdown = (props: DropdownProps) => {
     if (menuProps) {
         ({ width, fullWidth } = menuProps);
     } else {
-        width = '300px';
+        width = `${DROPDOWN_MENU_DEFAULT_WIDTH}px`;
         fullWidth = true;
     }
 
     const [isOpen, setIsOpen] = useState<boolean>(false);
-    const [dropdownMenuHeight, setDropdownMenuHeight] = useState(
-        DROPDOWN_MENU_MAX_HEIGHT
-    );
+    const [dropdownMenuSize, setDropdownMenuSize] = useState({
+        height: DROPDOWN_MENU_MAX_HEIGHT,
+        width: DROPDOWN_MENU_DEFAULT_WIDTH,
+    });
     const [selectedOptions, setSelectedOptions] = useState<
         BaseItemOptionProps | BaseItemOptionProps[]
     >(getSelectedValuesForDropdownType(multiple, value));
@@ -58,10 +63,18 @@ const Dropdown = (props: DropdownProps) => {
         setSelectedOptions(getSelectedValuesForDropdownType(multiple, value));
     }, [value, items, multiple]);
 
-    useEffect(() => {
-        if (isOpen && dropdownMenuRef.current) {
-            setDropdownMenuHeight(dropdownMenuRef.current.clientHeight);
+    useIsomorphicLayoutEffect(() => {
+        if (!isOpen || !dropdownMenuRef.current) {
+            return;
         }
+        // offset*, not client*, so the menu's border counts toward the space
+        // it occupies and the clamp keeps the full box on screen.
+        const { offsetHeight, offsetWidth } = dropdownMenuRef.current;
+        setDropdownMenuSize((previous) =>
+            previous.height === offsetHeight && previous.width === offsetWidth
+                ? previous
+                : { height: offsetHeight, width: offsetWidth }
+        );
     }, [isOpen]);
 
     return (
@@ -81,7 +94,8 @@ const Dropdown = (props: DropdownProps) => {
                     key="dropdown-menu-overlay"
                     position={calculateDropdownMenuPosition(
                         triggerRef,
-                        dropdownMenuHeight
+                        dropdownMenuSize.height,
+                        dropdownMenuSize.width
                     )}
                     shouldFocusOnFirstElement
                     shouldDisableScroll={isOpen}

--- a/ui/elements/Form/Dropdown/utils.test.ts
+++ b/ui/elements/Form/Dropdown/utils.test.ts
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import { DROPDOWN_MENU_OFFSET_Y } from '../../DropdownMenu/constants';
 import { calculateDropdownMenuPosition } from './utils';
 
 const VIEWPORT_WIDTH = 1280;
 const VIEWPORT_HEIGHT = 720;
+const GAP = 20;
 
 const setViewport = (width: number, height: number) => {
     window.innerWidth = width;
@@ -49,19 +51,50 @@ describe('calculateDropdownMenuPosition', () => {
         );
 
         // Anchoring at 1155 would push the menu 155px past the viewport.
-        expect(position.left).toBe(VIEWPORT_WIDTH - 280 - 20);
+        expect(position.left).toBe(VIEWPORT_WIDTH - 280 - GAP);
         expect(position.left + 280).toBeLessThanOrEqual(VIEWPORT_WIDTH);
     });
 
     it('pulls the menu back in when the trigger sits near the bottom edge', () => {
+        const menuHeight = 300;
         const position = calculateDropdownMenuPosition(
             triggerAt({ left: 100, bottom: 700 }),
+            menuHeight,
+            280
+        );
+
+        // The menu settles DROPDOWN_MENU_OFFSET_Y below the position it is
+        // given, so that offset has to stay on screen too.
+        expect(
+            position.top + DROPDOWN_MENU_OFFSET_Y + menuHeight
+        ).toBeLessThanOrEqual(VIEWPORT_HEIGHT);
+    });
+
+    // Regression: fullWidth is the default, so on a narrow viewport the menu is
+    // exactly as wide as its trigger. Reserving a gap it does not need would
+    // shift the menu out of alignment with the trigger it belongs to.
+    it('keeps a full-width menu on a narrow viewport flush with its trigger', () => {
+        setViewport(375, 812);
+
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 16, bottom: 200, width: 343 }),
+            300,
+            343
+        );
+
+        expect(position.left).toBe(16);
+    });
+
+    it('leaves a menu alone whenever it already fits', () => {
+        // Right edge of the menu landing exactly on the viewport edge still
+        // counts as fitting, and must not be nudged.
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: VIEWPORT_WIDTH - 280, bottom: 60 }),
             300,
             280
         );
 
-        expect(position.top).toBe(VIEWPORT_HEIGHT - 300 - 20);
-        expect(position.top + 300).toBeLessThanOrEqual(VIEWPORT_HEIGHT);
+        expect(position.left).toBe(VIEWPORT_WIDTH - 280);
     });
 
     it('keeps a trigger closer to an edge than the gap flush with the trigger', () => {

--- a/ui/elements/Form/Dropdown/utils.test.ts
+++ b/ui/elements/Form/Dropdown/utils.test.ts
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import { calculateDropdownMenuPosition } from './utils';
+
+const VIEWPORT_WIDTH = 1280;
+const VIEWPORT_HEIGHT = 720;
+
+const setViewport = (width: number, height: number) => {
+    window.innerWidth = width;
+    window.innerHeight = height;
+};
+
+/** A trigger ref whose only job is to report a rect. */
+const triggerAt = (rect: Partial<DOMRect>) =>
+    ({
+        current: {
+            getBoundingClientRect: () => ({
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0,
+                width: 0,
+                height: 0,
+                ...rect,
+            }),
+        },
+    } as React.RefObject<HTMLButtonElement>);
+
+describe('calculateDropdownMenuPosition', () => {
+    beforeEach(() => {
+        setViewport(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+    });
+
+    it('anchors to the trigger when the menu fits on screen', () => {
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 100, bottom: 60 }),
+            300,
+            280
+        );
+
+        expect(position).toEqual({ top: 60, left: 100 });
+    });
+
+    it('pulls the menu back in when the trigger sits near the right edge', () => {
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 1155, bottom: 60 }),
+            300,
+            280
+        );
+
+        // Anchoring at 1155 would push the menu 155px past the viewport.
+        expect(position.left).toBe(VIEWPORT_WIDTH - 280 - 20);
+        expect(position.left + 280).toBeLessThanOrEqual(VIEWPORT_WIDTH);
+    });
+
+    it('pulls the menu back in when the trigger sits near the bottom edge', () => {
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 100, bottom: 700 }),
+            300,
+            280
+        );
+
+        expect(position.top).toBe(VIEWPORT_HEIGHT - 300 - 20);
+        expect(position.top + 300).toBeLessThanOrEqual(VIEWPORT_HEIGHT);
+    });
+
+    it('keeps a trigger closer to an edge than the gap flush with the trigger', () => {
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 4, bottom: 8 }),
+            300,
+            280
+        );
+
+        expect(position).toEqual({ top: 8, left: 4 });
+    });
+
+    it('stays on screen when the menu is larger than the viewport', () => {
+        setViewport(320, 400);
+
+        const position = calculateDropdownMenuPosition(
+            triggerAt({ left: 200, bottom: 380 }),
+            500,
+            360
+        );
+
+        expect(position).toEqual({ top: 0, left: 0 });
+    });
+
+    it('falls back to the origin when the trigger is not mounted', () => {
+        const position = calculateDropdownMenuPosition(
+            { current: null } as React.RefObject<HTMLButtonElement>,
+            300,
+            280
+        );
+
+        expect(position).toEqual({ top: 0, left: 0 });
+    });
+});

--- a/ui/elements/Form/Dropdown/utils.ts
+++ b/ui/elements/Form/Dropdown/utils.ts
@@ -1,21 +1,62 @@
 import React from 'react';
 
+import { DROPDOWN_MENU_VIEWPORT_GAP } from '../../DropdownMenu/constants';
+
+/**
+ * Keeps one axis of the dropdown menu inside the viewport.
+ *
+ * The anchored position is preferred, so a menu that already fits stays exactly
+ * where its trigger puts it. The upper bound pulls the menu back in when the
+ * trigger sits near the far edge, leaving a small gap. The lower bound is the
+ * near edge itself rather than that gap: it exists only to stop a menu too large
+ * for the viewport from running off the near side, and using the gap here would
+ * needlessly break alignment for a trigger placed within it.
+ *
+ * @param anchor - The preferred position, taken from the trigger.
+ * @param menuSize - The menu's size along this axis.
+ * @param viewportSize - The viewport's size along this axis.
+ */
+function clampToViewport(
+    anchor: number,
+    menuSize: number,
+    viewportSize: number
+) {
+    return Math.max(
+        0,
+        Math.min(anchor, viewportSize - menuSize - DROPDOWN_MENU_VIEWPORT_GAP)
+    );
+}
+
 /**
  * Calculates the position for a dropdown menu based on the position of a trigger element.
  *
- * @param triggerRef - A reference to the HTMLDivElement that triggers the dropdown menu.
+ * The menu is anchored under the trigger and then clamped on both axes, so a
+ * trigger near an edge of the viewport cannot push the menu off screen. This
+ * matters because the menu opens in a fixed overlay that disables page scroll,
+ * so anything pushed out of view would otherwise be unreachable.
+ *
+ * @param triggerRef - A reference to the element that triggers the dropdown menu.
  * @param menuHeight - The height of the dropdown menu.
+ * @param menuWidth - The width of the dropdown menu.
  * @returns An object containing the top and left positions for the dropdown menu.
  */
 export function calculateDropdownMenuPosition(
     triggerRef: React.RefObject<HTMLButtonElement | HTMLDivElement>,
-    menuHeight: number
+    menuHeight: number,
+    menuWidth: number
 ) {
+    const triggerRect = triggerRef.current?.getBoundingClientRect();
+
+    if (!triggerRect) {
+        return { top: 0, left: 0 };
+    }
+
     return {
-        top: Math.min(
-            triggerRef.current?.getBoundingClientRect().bottom,
-            window.innerHeight - menuHeight - 20
+        top: clampToViewport(
+            triggerRect.bottom,
+            menuHeight,
+            window.innerHeight
         ),
-        left: triggerRef.current?.getBoundingClientRect().left,
+        left: clampToViewport(triggerRect.left, menuWidth, window.innerWidth),
     };
 }

--- a/ui/elements/Form/Dropdown/utils.ts
+++ b/ui/elements/Form/Dropdown/utils.ts
@@ -1,39 +1,17 @@
 import React from 'react';
 
-import { DROPDOWN_MENU_VIEWPORT_GAP } from '../../DropdownMenu/constants';
-
-/**
- * Keeps one axis of the dropdown menu inside the viewport.
- *
- * The anchored position is preferred, so a menu that already fits stays exactly
- * where its trigger puts it. The upper bound pulls the menu back in when the
- * trigger sits near the far edge, leaving a small gap. The lower bound is the
- * near edge itself rather than that gap: it exists only to stop a menu too large
- * for the viewport from running off the near side, and using the gap here would
- * needlessly break alignment for a trigger placed within it.
- *
- * @param anchor - The preferred position, taken from the trigger.
- * @param menuSize - The menu's size along this axis.
- * @param viewportSize - The viewport's size along this axis.
- */
-function clampToViewport(
-    anchor: number,
-    menuSize: number,
-    viewportSize: number
-) {
-    return Math.max(
-        0,
-        Math.min(anchor, viewportSize - menuSize - DROPDOWN_MENU_VIEWPORT_GAP)
-    );
-}
+import { DROPDOWN_MENU_OFFSET_Y } from '../../DropdownMenu/constants';
+import { clampMenuAxisToViewport } from '../../DropdownMenu/utils';
 
 /**
  * Calculates the position for a dropdown menu based on the position of a trigger element.
  *
- * The menu is anchored under the trigger and then clamped on both axes, so a
- * trigger near an edge of the viewport cannot push the menu off screen. This
- * matters because the menu opens in a fixed overlay that disables page scroll,
- * so anything pushed out of view would otherwise be unreachable.
+ * The menu is anchored under the trigger and then fitted to the viewport on both
+ * axes, so a trigger near an edge cannot push the menu off screen. This matters
+ * because the menu opens in a fixed overlay that disables page scroll, so
+ * anything pushed out of view would otherwise be unreachable.
+ *
+ * A menu that already fits is not moved, so existing placements are unaffected.
  *
  * @param triggerRef - A reference to the element that triggers the dropdown menu.
  * @param menuHeight - The height of the dropdown menu.
@@ -52,11 +30,17 @@ export function calculateDropdownMenuPosition(
     }
 
     return {
-        top: clampToViewport(
+        // The menu settles a little below the position it is given, so that
+        // offset counts toward the space it needs.
+        top: clampMenuAxisToViewport(
             triggerRect.bottom,
-            menuHeight,
+            menuHeight + DROPDOWN_MENU_OFFSET_Y,
             window.innerHeight
         ),
-        left: clampToViewport(triggerRect.left, menuWidth, window.innerWidth),
+        left: clampMenuAxisToViewport(
+            triggerRect.left,
+            menuWidth,
+            window.innerWidth
+        ),
     };
 }


### PR DESCRIPTION
## The bug

Open an `NSDropdown` whose trigger sits near the right edge of the viewport and the menu renders partly off screen, with no way to reach the hidden part.

Reported on newton-web's university portal (Summary tab → Instructors → the "Filter / All subjects" control), but nothing there is at fault — it passes ordinary props. Any right-aligned menu hits this.

## Root cause

`calculateDropdownMenuPosition` clamped only the vertical axis:

```ts
top: Math.min(triggerRect.bottom, window.innerHeight - menuHeight - 20),
left: triggerRect.left,   // ← no bound at all
```

A 280px menu on a trigger at `left: 1155` in a 1280px viewport rendered at **1155 → 1435**: 155px outside.

It is unreachable rather than merely awkward, because the menu opens inside an `Overlay` with `shouldDisableScroll` — page scroll is off while the menu is open.

## This affects two components, not one

`DropdownMenu` is positioned by three different systems, and they had drifted:

| Component | Positioning | Horizontal fit |
|---|---|---|
| `Form/Dropdown` (`NSDropdown`) | own `calculateDropdownMenuPosition` | ❌ none — **fixed here** |
| `Form/Combobox` | own `calculateDropdownMenuLayoutForCombobox` | ❌ none — **fixed here** |
| `SelectDropdown`, `MultiSelectDropdown` | `PopOver` | ✅ already handled |

Combobox held an independently written copy of the same unbounded `left: triggerRect.left`, in **both** its downward and upward branches. Fixing only `Dropdown` would have left it broken.

The fit is now a single `clampMenuAxisToViewport` in `DropdownMenu/utils`, used by both callers — one implementation rather than two that drift apart again.

## Only adjusting on a real overflow

The first commit clamped unconditionally with `Math.min`. That was wrong, and it regressed a very common case.

`fullWidth` is the **default** when `menuProps` is omitted, which makes the menu exactly as wide as its trigger. Reserving a 20px gap it does not need shifts it out of alignment with the trigger it belongs to. On a 375px viewport, a full-width menu with 16px gutters moved to **12px** — 4px out of alignment, on every mobile form dropdown.

`PopOver` already had the right rule (`if (popOverRect.right > parentRight)`), so the clamp now matches it: **a menu that already fits is never moved.** The adjustment engages only on a genuine overflow, and pulls back to leave a gap, or flush to the near edge when the menu is larger than the viewport.

This is locked down by a test that fails against the first commit:

```
● keeps a full-width menu on a narrow viewport flush with its trigger
  Expected: 16
  Received: 12
```

## The settled 8px offset

The menu rests 8px below the position it is given — applied as a transform by the entry animation, so it never appears in the menu's own box. It is now `DROPDOWN_MENU_OFFSET_Y`, shared by the animation and the vertical fit, which previously could have let that offset hang past the bottom edge.

## Verification

Measured in Storybook with the portal's exact props:

| | `left` → `right` | viewport | off screen |
|---|---|---|---|
| before | 1155 → **1435** | 1280 | **155px** |
| after | 980 → 1260 | 1280 | none (20px gap) |

Also checked: bottom-edge clamp (trigger at `bottom: 868` in a 1002px viewport → `top: 484`), near-edge alignment (trigger at `left: 16` stays at 16), and the full-width mobile case visually at 375px.

`tsc --noEmit` clean · eslint clean · prettier clean · **full suite 424/424 across 48 suites**.

## Backward compatibility

- `clampMenuAxisToViewport`'s `menuWidth` defaults to `0`, which is a no-op — any caller that does not measure keeps its exact current placement.
- `calculateDropdownMenuPosition` and `calculateDropdownMenuLayoutForCombobox` are both internal; `index.tsx` exports only the components and their props types.
- A menu that already fits is not moved, so existing placements are unchanged by construction.
- `useIsomorphicLayoutEffect` is added because consumers render grauity under Next.js SSR, where a bare `useLayoutEffect` warns.

## Not addressed

Position is computed on open and does not recompute on window resize while the menu is open. Pre-existing, and scroll is disabled meanwhile.

Longer term these three positioning systems should collapse into `PopOver`, which already does collision handling properly. That is a refactor, not a bug fix, so it does not belong here.

## Follow-up

newton-web pins `@newtonschool/grauity@3.5.4` and needs a version bump once this is released. No newton-web code change is required — 89 `NSDropdown` render sites there, all using ordinary props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)